### PR TITLE
bugfix: relative and absolute paths

### DIFF
--- a/miniscope_io/io.py
+++ b/miniscope_io/io.py
@@ -32,7 +32,7 @@ class SDCard:
             layout: SDLayout
         ):
 
-        self.drive = Path(drive)
+        self.drive = drive
         self.layout = layout
 
         # Private attributes used when the file reading context is entered

--- a/miniscope_io/io.py
+++ b/miniscope_io/io.py
@@ -29,15 +29,10 @@ class SDCard:
     def __init__(
             self,
             drive: Union[str, Path],
-            layout: SDLayout,
-            directpath: bool = False
+            layout: SDLayout
         ):
 
-        if directpath == False:
-            self.drive = Path(drive).resolve()
-        else:
-            self.drive = drive
-    # Logs the error appropriately. 
+        self.drive = Path(drive)
         self.layout = layout
 
         # Private attributes used when the file reading context is entered
@@ -72,20 +67,17 @@ class SDCard:
     @property
     def config(self) -> SDConfig:
         if self._config is None:
-            try:
-                with open(self.drive, 'rb') as sd:
-                    sd.seek(self.layout.sectors.config_pos, 0)
-                    configSectorData = np.frombuffer(sd.read(self.layout.sectors.size), dtype=np.uint32)
+            with open(self.drive, 'rb') as sd:
+                sd.seek(self.layout.sectors.config_pos, 0)
+                configSectorData = np.frombuffer(sd.read(self.layout.sectors.size), dtype=np.uint32)
 
-                self._config = SDConfig(
-                    **{
-                        k: configSectorData[v]
-                        for k, v in self.layout.config.dict().items()
-                        if v is not None
-                    }
-                )
-            except Exception as error:
-                print("An exception occurred:", error)
+            self._config = SDConfig(
+                **{
+                    k: configSectorData[v]
+                    for k, v in self.layout.config.dict().items()
+                    if v is not None
+                }
+            )
 
         return self._config
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,6 +1,10 @@
 import pytest
+from pathlib import Path
+import os
 
 from miniscope_io.sdcard import DataHeader
+from miniscope_io.formats import WireFreeSDLayout
+from miniscope_io.io import SDCard
 from miniscope_io.exceptions import EndOfRecordingException
 from miniscope_io.data import Frame
 
@@ -76,6 +80,31 @@ def test_frame_count(wirefree):
         wirefree.frame = 389
         with pytest.raises(EndOfRecordingException):
             frame = wirefree.read()
+
+def test_relative_path():
+    """
+    Test that we can use both relative and absolute paths in the SD card model
+    """
+    # get absolute path of working directory, then get relative path to data from there
+    abs_cwd = Path(os.getcwd()).resolve()
+    abs_child = Path(__file__).parent.parent / 'data' / 'wirefree_example.img'
+    rel_path = abs_child.relative_to(abs_cwd)
+
+    assert not rel_path.is_absolute()
+    sdcard = SDCard(drive = rel_path, layout = WireFreeSDLayout)
+
+    # check we can do something basic like read config
+    assert sdcard.config is not None
+
+    # check it remains relative after init
+    assert not sdcard.drive.is_absolute()
+
+    # now try with an absolute path
+    abs_path = rel_path.resolve()
+    assert abs_path.is_absolute()
+    sdcard_abs = SDCard(drive= abs_path, layout= WireFreeSDLayout)
+    assert sdcard_abs.config is not None
+    assert sdcard_abs.drive.is_absolute()
 
 
 #


### PR DESCRIPTION
Previously, sdcard would try and `resolve` every path given to it. Now that behavior has been removed, allowing both relative and absolute paths.

reinstated throwing an exception when config can't be read, as that should stop any further use of the object since something has gone wrong with reading from it

Related to: 
- https://github.com/Aharoni-Lab/miniscope-io/pull/8#issuecomment-1704502701
Closes:
- https://github.com/Aharoni-Lab/miniscope-io/issues/6

@t-sasatani I removed the try block around reading the config which was also added in https://github.com/Aharoni-Lab/miniscope-io/commit/bc9370a612ae69b9d182f08f8379762026004ba6 - i figured removing the `resolve` addresses the reason it was added? seems like throwing an I/O error there if the config can't be read is good to do, since the object shouldn't be used after that point if the file can't be read.
