### PR TITLE
Support dummy words in stream buffer beginning

### DIFF
--- a/docs/device/test_device.md
+++ b/docs/device/test_device.md
@@ -3,8 +3,8 @@
 **Under Construction:** This section will be populated when devices are released.
 
 ## Buffer Structure
-- **Constituents**: The buffer consists of a concatenation of 32-bit header data and 8-bit pixel data.
-- **Storage**: A single image is split and stored in a circulating buffer within the device. The [`num_buffers`](../api/stream_daq.md) should match the number of circulating buffers in the device.
+- **Contents**: The buffer consists of a concatenation of 32-bit dummy words, 32-bit header data, and 8-bit pixel data. The dummy words are for stabilizing the clock recovery function in the Manchester decoder FPGA, and the header data is used for recovering images and detecting device status.
+- **Payload**: A single image is split and stored in a circulating buffer within the device. The [`num_buffers`](../api/stream_daq.md) should match the number of circulating buffers in the device.
 
 ## Header Values and Expected Transitions
 See following docs for the basic structure.

--- a/miniscope_io/data/config/WLMS_v02_200px.yml
+++ b/miniscope_io/data/config/WLMS_v02_200px.yml
@@ -21,6 +21,7 @@ header_len: 384 # 12 * 32 (in bits)
 buffer_block_length: 10
 block_size: 512
 num_buffers: 32
+dummy_words: 10
 
 # Flags to flip bit/byte order when recovering headers and data. See model document for details.
 reverse_header_bits: True

--- a/miniscope_io/models/stream.py
+++ b/miniscope_io/models/stream.py
@@ -152,6 +152,10 @@ class StreamDevConfig(MiniscopeConfig, YAMLMixin):
         If True, reverse the byte order within each 32-bit word of the payload.
         This is used for handling endianness in systems where the byte order needs to be swapped.
         Default is False.
+    dummy_words : int, optional
+        Number of 32-bit dummy words in the header.
+        This is used to stabilize clock recovery in FPGA Manchester decoder.
+        This value does not have a meaning for image recovery.
 
     ..todo::
         Move port (for USART) to a user config area. This should make this pure device config.
@@ -174,8 +178,8 @@ class StreamDevConfig(MiniscopeConfig, YAMLMixin):
     reverse_header_bytes: bool = False
     reverse_payload_bits: bool = False
     reverse_payload_bytes: bool = False
-    runtime: StreamDevRuntime = StreamDevRuntime()
     dummy_words: int = 0
+    runtime: StreamDevRuntime = StreamDevRuntime()
 
     @field_validator("preamble", mode="before")
     def preamble_to_bytes(cls, value: Union[str, bytes, int]) -> bytes:

--- a/miniscope_io/models/stream.py
+++ b/miniscope_io/models/stream.py
@@ -175,6 +175,7 @@ class StreamDevConfig(MiniscopeConfig, YAMLMixin):
     reverse_payload_bits: bool = False
     reverse_payload_bytes: bool = False
     runtime: StreamDevRuntime = StreamDevRuntime()
+    dummy_words: int = 0
 
     @field_validator("preamble", mode="before")
     def preamble_to_bytes(cls, value: Union[str, bytes, int]) -> bytes:

--- a/miniscope_io/stream_daq.py
+++ b/miniscope_io/stream_daq.py
@@ -118,11 +118,11 @@ class StreamDaq:
         """List of pixels per buffer for a frame"""
         if self._buffer_npix is None:
             px_per_frame = self.config.frame_width * self.config.frame_height
-            byte_per_word = np.iinfo(np.int32).bits / np.iinfo(np.int8).bits 
+            byte_per_word = np.iinfo(np.int32).bits / np.iinfo(np.int8).bits
 
             px_per_buffer = (
                 self.config.buffer_block_length * self.config.block_size
-                - self.config.header_len / np.iinfo(np.int8).bits 
+                - self.config.header_len / np.iinfo(np.int8).bits
                 - self.config.dummy_words * byte_per_word
             )
             quotient, remainder = divmod(px_per_frame, px_per_buffer)
@@ -176,11 +176,17 @@ class StreamDaq:
     ) -> np.ndarray:
         """
         Trim or pad an array to match an expected size
+
+        .. todo::
+            Re-think about the timing to deal with dummy words.
+            It feels cleaner to remove these dummy words right after the preamble detections.
+            That way, all data we inject into later stages will be pure metadata and pixel data.
+            This isn't critical and I don't want to slow down detection so skipping for now.
         """
         expected_payload_size = expected_size_array[0]
         expected_data_size = expected_size_array[header.frame_buffer_count]
 
-        # This is temporary. It's better to detect all dummy words and remove them.
+        # This validation is temporary. More info in todo above.
         if data.shape[0] != expected_payload_size + self.config.dummy_words * 4:
             logger.warning(
                 f"Frame {header.frame_num}; Buffer {header.buffer_count} "

--- a/miniscope_io/stream_daq.py
+++ b/miniscope_io/stream_daq.py
@@ -120,7 +120,8 @@ class StreamDaq:
             px_per_frame = self.config.frame_width * self.config.frame_height
             px_per_buffer = (
                 self.config.buffer_block_length * self.config.block_size
-                - self.config.header_len / 8 - self.config.dummy_words * 4
+                - self.config.header_len / 8
+                - self.config.dummy_words * 4
             )
             quotient, remainder = divmod(px_per_frame, px_per_buffer)
             self._buffer_npix = [int(px_per_buffer)] * int(quotient) + [int(remainder)]

--- a/miniscope_io/stream_daq.py
+++ b/miniscope_io/stream_daq.py
@@ -118,10 +118,12 @@ class StreamDaq:
         """List of pixels per buffer for a frame"""
         if self._buffer_npix is None:
             px_per_frame = self.config.frame_width * self.config.frame_height
+            byte_per_word = np.iinfo(np.int32).bits / np.iinfo(np.int8).bits 
+
             px_per_buffer = (
                 self.config.buffer_block_length * self.config.block_size
-                - self.config.header_len / 8
-                - self.config.dummy_words * 4
+                - self.config.header_len / np.iinfo(np.int8).bits 
+                - self.config.dummy_words * byte_per_word
             )
             quotient, remainder = divmod(px_per_frame, px_per_buffer)
             self._buffer_npix = [int(px_per_buffer)] * int(quotient) + [int(remainder)]

--- a/miniscope_io/stream_daq.py
+++ b/miniscope_io/stream_daq.py
@@ -456,8 +456,11 @@ class StreamDaq:
         try:
             for frame_data, header_list in exact_iter(frame_buffer_queue.get, None):
 
-                locallogs.debug("Found frame in queue")
+                if not frame_data:
+                    imagearray.put((None, header_list))
+                    continue
                 if len(frame_data) == 0:
+                    imagearray.put((None, header_list))
                     continue
                 frame_data = np.concatenate(frame_data, axis=0)
 

--- a/miniscope_io/stream_daq.py
+++ b/miniscope_io/stream_daq.py
@@ -120,7 +120,7 @@ class StreamDaq:
             px_per_frame = self.config.frame_width * self.config.frame_height
             px_per_buffer = (
                 self.config.buffer_block_length * self.config.block_size
-                - self.config.header_len / 8
+                - self.config.header_len / 8 - self.config.dummy_words * 4
             )
             quotient, remainder = divmod(px_per_frame, px_per_buffer)
             self._buffer_npix = [int(px_per_buffer)] * int(quotient) + [int(remainder)]

--- a/miniscope_io/stream_daq.py
+++ b/miniscope_io/stream_daq.py
@@ -177,7 +177,8 @@ class StreamDaq:
         expected_payload_size = expected_size_array[0]
         expected_data_size = expected_size_array[header.frame_buffer_count]
 
-        if data.shape[0] != expected_payload_size:
+        # This is temporary. It's better to detect all dummy words and remove them.
+        if data.shape[0] != expected_payload_size + self.config.dummy_words * 4:
             logger.warning(
                 f"Frame {header.frame_num}; Buffer {header.buffer_count} "
                 f"(#{header.frame_buffer_count} in frame)\n"

--- a/tests/test_stream_daq.py
+++ b/tests/test_stream_daq.py
@@ -104,7 +104,7 @@ def test_csv_output(tmp_path, default_streamdaq, write_metadata, caplog):
         # actually not sure what we should be looking for here, for now we just check for shape
         # this should be the same as long as the test data stays the same,
         # but it's a pretty weak test.
-        assert df.shape == (909, 11)
+        assert df.shape == (910, 11)
 
         # ensure there were no errors during capture
         for record in caplog.records:


### PR DESCRIPTION
This patch PR handles dummy words at the beginning of the data buffers. This gives the FPGA a little bit of time to recover clock signals before the actual preamble detection starts. It runs the same as `v0.4.0` if `dummy_bytes = 0`. 

@MarcelMB found that signal polarity between buffer transfers affects the decoder's performance. We noticed that clock recovery might not be working well for the first few bits, and this PR addresses that. Now, the wired image transfer works with almost no errors, and I think the wireless runs more stable than before (I'm not sure about this, but it might also solve #36.)