### PR TITLE
ADC-voltage conversion in StreamBufferHeader model

### DIFF
--- a/docs/meta/changelog.md
+++ b/docs/meta/changelog.md
@@ -2,6 +2,16 @@
 
 ## 0.4
 
+### 0.4.1 - 24-09-01
+
+#### Added Features
+- Support dummy words at the beginning of buffer to make data detection in `StreamDaq` more robust. The length of this word can be set via the device config YAML file.
+- `models.stream.ADCScaling` class for converting ADC raw values into voltage. The scaling factors can be set via the device config YAML file.
+
+Related PRs: [#41](https://github.com/Aharoni-Lab/miniscope-io/pull/41), [#44](https://github.com/Aharoni-Lab/miniscope-io/pull/44)
+Related Issues: [#36](https://github.com/Aharoni-Lab/miniscope-io/issues/36)
+Contributors: [@t-sasatani](https://github.com/t-sasatani), [@sneakers-the-rat](https://github.com/sneakers-the-rat), [@MarcelMB](https://github.com/MarcelMB).
+
 ### 0.4.0 - 24-08-27
 
 Enhancements and bugfixes to `StreamDaq`. Mostly around handling metadata.

--- a/miniscope_io/data/config/WLMS_v02_200px.yml
+++ b/miniscope_io/data/config/WLMS_v02_200px.yml
@@ -29,6 +29,12 @@ reverse_header_bytes: True
 reverse_payload_bits: True
 reverse_payload_bytes: True
 
+adc_scale:
+  ref_voltage: 1.1
+  bitdepth: 8
+  battery_div_factor: 5
+  vin_div_factor: 11.3
+
 runtime:
   serial_buffer_queue_size: 10
   frame_buffer_queue_size: 5
@@ -40,6 +46,7 @@ runtime:
       - timestamp
       - buffer_count
       - frame_buffer_count
+      - battery_voltage
+      - input_voltage
     update_ms: 1000
     history: 500
-

--- a/miniscope_io/formats/stream.py
+++ b/miniscope_io/formats/stream.py
@@ -15,6 +15,6 @@ StreamBufferHeader = StreamBufferHeaderFormat(
     timestamp=6,
     pixel_count=7,
     write_timestamp=8,
-    battery_voltage_adc=9,
-    input_voltage_adc=10,
+    battery_voltage_raw=9,
+    input_voltage_raw=10,
 )

--- a/miniscope_io/formats/stream.py
+++ b/miniscope_io/formats/stream.py
@@ -15,6 +15,6 @@ StreamBufferHeader = StreamBufferHeaderFormat(
     timestamp=6,
     pixel_count=7,
     write_timestamp=8,
-    battery_voltage=9,
-    ewl_pos=10,
+    battery_voltage_adc=9,
+    input_voltage_adc=10,
 )

--- a/miniscope_io/models/stream.py
+++ b/miniscope_io/models/stream.py
@@ -14,7 +14,7 @@ from miniscope_io.models.mixins import YAMLMixin
 from miniscope_io.models.sinks import CSVWriterConfig, StreamPlotterConfig
 
 
-class adcScaling(MiniscopeConfig):
+class ADCScaling(MiniscopeConfig):
     """
     Configuration for the ADC scaling factors
     """
@@ -52,14 +52,14 @@ class StreamBufferHeaderFormat(BufferHeaderFormat):
     vin_voltage: int
         Input voltage. This is currently raw ADC value.
         Mapping to mV will be documented in device documentation.
-    _adc_scaling: adcScaling
+    _adc_scaling: ADCScaling
         Scaling factors for the ADC. This is used to convert raw ADC values to voltages.
     """
 
     pixel_count: int
     battery_voltage_adc: int
     input_voltage_adc: int
-    _adc_scaling: adcScaling = None
+    _adc_scaling: ADCScaling = None
 
 
 class StreamBufferHeader(BufferHeader):
@@ -71,9 +71,9 @@ class StreamBufferHeader(BufferHeader):
     pixel_count: int
     battery_voltage_adc: int
     input_voltage_adc: int
-    _adc_scaling: adcScaling = None
+    _adc_scaling: ADCScaling = None
 
-    def set_adc_scaling(self, scaling: adcScaling) -> None:
+    def set_adc_scaling(self, scaling: ADCScaling) -> None:
         """
         set adc scaling in the header format
         """
@@ -242,7 +242,7 @@ class StreamDevConfig(MiniscopeConfig, YAMLMixin):
     reverse_payload_bits: bool = False
     reverse_payload_bytes: bool = False
     dummy_words: int = 0
-    adc_scale: adcScaling = adcScaling()
+    adc_scale: ADCScaling = ADCScaling()
     runtime: StreamDevRuntime = StreamDevRuntime()
 
     @field_validator("preamble", mode="before")

--- a/miniscope_io/models/stream.py
+++ b/miniscope_io/models/stream.py
@@ -18,6 +18,7 @@ class adcScaling(MiniscopeConfig):
     """
     Configuration for the ADC scaling factors
     """
+
     ref_voltage: float = Field(
         1.1,
         description="Reference voltage of the ADC",
@@ -34,7 +35,8 @@ class adcScaling(MiniscopeConfig):
         11.3,
         description="Voltage divider factor for the Vin voltage",
     )
-    
+
+
 class StreamBufferHeaderFormat(BufferHeaderFormat):
     """
     Refinements of :class:`.BufferHeaderFormat` for
@@ -59,6 +61,7 @@ class StreamBufferHeaderFormat(BufferHeaderFormat):
     input_voltage_adc: int
     _adc_scaling: adcScaling = None
 
+
 class StreamBufferHeader(BufferHeader):
     """
     Refinements of :class:`.BufferHeader` for
@@ -70,7 +73,7 @@ class StreamBufferHeader(BufferHeader):
     input_voltage_adc: int
     _adc_scaling: adcScaling = None
 
-    def set_adc_scaling(self, scaling: adcScaling)-> None:
+    def set_adc_scaling(self, scaling: adcScaling) -> None:
         """
         set adc scaling in the header format
         """
@@ -84,9 +87,10 @@ class StreamBufferHeader(BufferHeader):
         if self._adc_scaling is None:
             raise ValueError("ADC scaling factors not set")
         return (
-            self.battery_voltage_adc / 2**self._adc_scaling.bitdepth *
-            self._adc_scaling.ref_voltage *
-            self._adc_scaling.battery_div_factor
+            self.battery_voltage_adc
+            / 2**self._adc_scaling.bitdepth
+            * self._adc_scaling.ref_voltage
+            * self._adc_scaling.battery_div_factor
         )
 
     @property
@@ -97,10 +101,12 @@ class StreamBufferHeader(BufferHeader):
         if self._adc_scaling is None:
             raise ValueError("ADC scaling factors not set")
         return (
-            self.input_voltage_adc / 2**self._adc_scaling.bitdepth *
-            self._adc_scaling.ref_voltage *
-            self._adc_scaling.battery_div_factor
+            self.input_voltage_adc
+            / 2**self._adc_scaling.bitdepth
+            * self._adc_scaling.ref_voltage
+            * self._adc_scaling.battery_div_factor
         )
+
 
 class StreamDevRuntime(MiniscopeConfig):
     """
@@ -138,6 +144,7 @@ class StreamDevRuntime(MiniscopeConfig):
         "Note that this does *not* control whether header metadata is written during capture, "
         "for enabling/disabling, use the ``metadata`` kwarg in the capture method.",
     )
+
 
 class StreamDevConfig(MiniscopeConfig, YAMLMixin):
     """

--- a/miniscope_io/models/stream.py
+++ b/miniscope_io/models/stream.py
@@ -104,7 +104,7 @@ class StreamBufferHeader(BufferHeader):
             self.input_voltage_adc
             / 2**self._adc_scaling.bitdepth
             * self._adc_scaling.ref_voltage
-            * self._adc_scaling.battery_div_factor
+            * self._adc_scaling.vin_div_factor
         )
 
 

--- a/miniscope_io/models/stream.py
+++ b/miniscope_io/models/stream.py
@@ -36,29 +36,29 @@ class ADCScaling(MiniscopeConfig):
         description="Voltage divider factor for the Vin voltage",
     )
 
-    def scale_battery_voltage(self, voltage_adc: float) -> float:
+    def scale_battery_voltage(self, voltage_raw: float) -> float:
         """
         Scale raw input ADC voltage to Volts
 
         Args:
-            voltage_adc: Voltage as output by the ADC
+            voltage_raw: Voltage as output by the ADC
 
         Returns:
             float: Scaled voltage
         """
-        return voltage_adc / 2**self.bitdepth * self.ref_voltage * self.battery_div_factor
+        return voltage_raw / 2**self.bitdepth * self.ref_voltage * self.battery_div_factor
 
-    def scale_input_voltage(self, voltage_adc: float) -> float:
+    def scale_input_voltage(self, voltage_raw: float) -> float:
         """
         Scale raw input ADC voltage to Volts
 
         Args:
-            voltage_adc: Voltage as output by the ADC
+            voltage_raw: Voltage as output by the ADC
 
         Returns:
             float: Scaled voltage
         """
-        return voltage_adc / 2**self.bitdepth * self.ref_voltage * self.vin_div_factor
+        return voltage_raw / 2**self.bitdepth * self.ref_voltage * self.vin_div_factor
 
 
 class StreamBufferHeaderFormat(BufferHeaderFormat):
@@ -79,8 +79,8 @@ class StreamBufferHeaderFormat(BufferHeaderFormat):
     """
 
     pixel_count: int
-    battery_voltage_adc: int
-    input_voltage_adc: int
+    battery_voltage_raw: int
+    input_voltage_raw: int
 
 
 class StreamBufferHeader(BufferHeader):
@@ -90,8 +90,8 @@ class StreamBufferHeader(BufferHeader):
     """
 
     pixel_count: int
-    battery_voltage_adc: int
-    input_voltage_adc: int
+    battery_voltage_raw: int
+    input_voltage_raw: int
     _adc_scaling: ADCScaling = None
 
     @property
@@ -111,9 +111,9 @@ class StreamBufferHeader(BufferHeader):
         Scaled battery voltage in Volts.
         """
         if self._adc_scaling is None:
-            return self.battery_voltage_adc
+            return self.battery_voltage_raw
         else:
-            return self._adc_scaling.scale_battery_voltage(self.battery_voltage_adc)
+            return self._adc_scaling.scale_battery_voltage(self.battery_voltage_raw)
 
     @computed_field
     def input_voltage(self) -> float:
@@ -121,9 +121,9 @@ class StreamBufferHeader(BufferHeader):
         Scaled input voltage in Volts.
         """
         if self._adc_scaling is None:
-            return self.input_voltage_adc
+            return self.input_voltage_raw
         else:
-            return self._adc_scaling.scale_input_voltage(self.input_voltage_adc)
+            return self._adc_scaling.scale_input_voltage(self.input_voltage_raw)
 
 
 class StreamDevRuntime(MiniscopeConfig):

--- a/miniscope_io/stream_daq.py
+++ b/miniscope_io/stream_daq.py
@@ -22,9 +22,9 @@ from miniscope_io.exceptions import EndOfRecordingException, StreamReadError
 from miniscope_io.formats.stream import StreamBufferHeader as StreamBufferHeaderFormat
 from miniscope_io.io import BufferedCSVWriter
 from miniscope_io.models.stream import (
+    ADCScaling,
     StreamBufferHeader,
     StreamDevConfig,
-    adcScaling,
 )
 from miniscope_io.models.stream import (
     StreamBufferHeaderFormat as StreamBufferHeaderFormatType,
@@ -701,7 +701,7 @@ class StreamDaq:
         writer: Optional[cv2.VideoWriter],
         show_metadata: bool,
         metadata: Optional[Path] = None,
-        adc_scaling: Optional[adcScaling] = None,
+        adc_scaling: Optional[ADCScaling] = None,
     ) -> None:
         """
         Inner handler for :meth:`.capture` to process the frames from the frame queue.

--- a/miniscope_io/stream_daq.py
+++ b/miniscope_io/stream_daq.py
@@ -22,7 +22,6 @@ from miniscope_io.exceptions import EndOfRecordingException, StreamReadError
 from miniscope_io.formats.stream import StreamBufferHeader as StreamBufferHeaderFormat
 from miniscope_io.io import BufferedCSVWriter
 from miniscope_io.models.stream import (
-    ADCScaling,
     StreamBufferHeader,
     StreamDevConfig,
 )
@@ -165,6 +164,7 @@ class StreamDaq:
         )
 
         header_data = StreamBufferHeader.from_format(header, self.header_fmt, construct=True)
+        header_data.adc_scaling = self.config.adc_scale
 
         return header_data, payload
 
@@ -647,7 +647,6 @@ class StreamDaq:
                     writer=writer,
                     show_metadata=show_metadata,
                     metadata=metadata,
-                    adc_scaling=self.config.adc_scale,
                 )
 
         except KeyboardInterrupt:
@@ -701,7 +700,6 @@ class StreamDaq:
         writer: Optional[cv2.VideoWriter],
         show_metadata: bool,
         metadata: Optional[Path] = None,
-        adc_scaling: Optional[ADCScaling] = None,
     ) -> None:
         """
         Inner handler for :meth:`.capture` to process the frames from the frame queue.
@@ -720,7 +718,6 @@ class StreamDaq:
         if show_metadata or metadata:
             for header in header_list:
                 if show_metadata:
-                    header.set_adc_scaling(adc_scaling)
                     self.logger.debug("Plotting header metadata")
                     try:
                         self._header_plotter.update(header)

--- a/miniscope_io/stream_daq.py
+++ b/miniscope_io/stream_daq.py
@@ -24,6 +24,7 @@ from miniscope_io.io import BufferedCSVWriter
 from miniscope_io.models.stream import (
     StreamBufferHeader,
     StreamDevConfig,
+    adcScaling,
 )
 from miniscope_io.models.stream import (
     StreamBufferHeaderFormat as StreamBufferHeaderFormatType,
@@ -646,6 +647,7 @@ class StreamDaq:
                     writer=writer,
                     show_metadata=show_metadata,
                     metadata=metadata,
+                    adc_scaling=self.config.adc_scale,
                 )
 
         except KeyboardInterrupt:
@@ -699,6 +701,7 @@ class StreamDaq:
         writer: Optional[cv2.VideoWriter],
         show_metadata: bool,
         metadata: Optional[Path] = None,
+        adc_scaling: Optional[adcScaling] = None,
     ) -> None:
         """
         Inner handler for :meth:`.capture` to process the frames from the frame queue.
@@ -717,6 +720,7 @@ class StreamDaq:
         if show_metadata or metadata:
             for header in header_list:
                 if show_metadata:
+                    header.set_adc_scaling(adc_scaling)
                     self.logger.debug("Plotting header metadata")
                     try:
                         self._header_plotter.update(header)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "miniscope_io"
-version = "0.4.0"
+version = "0.4.1"
 description = "Generic I/O for miniscopes"
 authors = [
     "sneakers-the-rat <JLSaunders987@gmail.com>",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,10 @@
 import os
+from pathlib import Path
+from typing import Union, Callable
+from datetime import datetime
 
 import pytest
-from typing import Union
-
-from pathlib import Path
-
+import yaml
 
 DATA_DIR = Path(__file__).parent / "data"
 CONFIG_DIR = DATA_DIR / "config"
@@ -47,3 +47,21 @@ def set_okdev_input(monkeypatch):
         os.environ["PYTEST_OKDEV_DATA_FILE"] = str(file)
 
     return _set_okdev_input
+
+
+@pytest.fixture()
+def config_override(tmp_path) -> Callable[[Path, dict], Path]:
+    """
+    Create a config file with some of its properties overridden
+    """
+
+    def _config_override(path: Path, config: dict) -> Path:
+        with open(path, "r") as f:
+            data = yaml.safe_load(f)
+        data.update(config)
+        out_path = tmp_path / f"config_override_{datetime.now().strftime('%H_%M_%S_%f')}.yml"
+        with open(out_path, "w") as f:
+            yaml.safe_dump(data, f)
+        return out_path
+
+    yield _config_override

--- a/tests/data/config/stream_daq_test_200px.yml
+++ b/tests/data/config/stream_daq_test_200px.yml
@@ -17,6 +17,7 @@ header_len: 384 # 12 * 32 (in bits)
 buffer_block_length: 10
 block_size: 512
 num_buffers: 32
+dummy_words: 0
 
 # Flags to flip bit/byte order when recovering headers and data. See model document for details.
 reverse_header_bits: True
@@ -24,6 +25,12 @@ reverse_header_bytes: True
 reverse_payload_bits: True
 reverse_payload_bytes: True
 
+adc_scale:
+  ref_voltage: 1.1
+  bitdepth: 8
+  battery_div_factor: 5
+  vin_div_factor: 11.3
+  
 runtime:
   serial_buffer_queue_size: 10
   frame_buffer_queue_size: 5

--- a/tests/test_models/test_model_stream.py
+++ b/tests/test_models/test_model_stream.py
@@ -57,8 +57,8 @@ def test_adc_scaling(scale, config_override):
     example = config_override(CONFIG_DIR / "stream_daq_test_200px.yml", {"adc_scale": adc_scale})
     instance_config = StreamDevConfig.from_yaml(example)
 
-    battery_voltage_adc = 200
-    input_voltage_adc = 250
+    battery_voltage_raw = 200
+    input_voltage_raw = 250
 
     instance_header = StreamBufferHeader(
         linked_list=0,
@@ -70,18 +70,18 @@ def test_adc_scaling(scale, config_override):
         timestamp=0,
         pixel_count=0,
         write_timestamp=0,
-        battery_voltage_adc=battery_voltage_adc,
-        input_voltage_adc=input_voltage_adc,
+        battery_voltage_raw=battery_voltage_raw,
+        input_voltage_raw=input_voltage_raw,
     )
     instance_header.adc_scaling = instance_config.adc_scale
 
     if scale is None:
-        assert instance_header.battery_voltage == battery_voltage_adc
-        assert instance_header.input_voltage == input_voltage_adc
+        assert instance_header.battery_voltage == battery_voltage_raw
+        assert instance_header.input_voltage == input_voltage_raw
 
     else:
         adcscale = ADCScaling(**adc_scale)
         assert instance_header.battery_voltage == adcscale.scale_battery_voltage(
-            battery_voltage_adc
+            battery_voltage_raw
         )
-        assert instance_header.input_voltage == adcscale.scale_input_voltage(input_voltage_adc)
+        assert instance_header.input_voltage == adcscale.scale_input_voltage(input_voltage_raw)

--- a/tests/test_models/test_model_stream.py
+++ b/tests/test_models/test_model_stream.py
@@ -5,11 +5,12 @@ from miniscope_io.models.stream import StreamDevConfig, StreamBufferHeader
 
 from ..conftest import CONFIG_DIR
 
+
 @pytest.mark.parametrize(
-    'config',
+    "config",
     [
-        'preamble_hex.yml',
-    ]
+        "preamble_hex.yml",
+    ],
 )
 def test_preamble_hex_parsing(config):
     """
@@ -19,23 +20,39 @@ def test_preamble_hex_parsing(config):
     config_file = CONFIG_DIR / config
 
     instance = StreamDevConfig.from_yaml(config_file)
-    assert instance.preamble == b'\x124Vx'
+    assert instance.preamble == b"\x124Vx"
+
 
 def test_absolute_bitstream():
     """
     Relative paths should be resolved relative to the devices dir
     """
-    example = CONFIG_DIR / 'wireless_example.yml'
+    example = CONFIG_DIR / "wireless_example.yml"
 
     instance = StreamDevConfig.from_yaml(example)
     assert instance.bitstream.is_absolute()
     assert str(instance.bitstream).startswith(str(DEVICE_DIR))
 
-def test_adc_scaling():
+
+_default_adc_scale = {
+    "ref_voltage": 1.1,
+    "bitdepth": 8,
+    "battery_div_factor": 5,
+    "vin_div_factor": 11.3,
+}
+
+
+@pytest.mark.parametrize("scale", [None, 1, 2, _default_adc_scale["ref_voltage"]])
+def test_adc_scaling(scale, config_override):
     """
     Test that the ADC scaling factors are correctly parsed
     """
-    example = CONFIG_DIR / 'stream_daq_test_200px.yml'
+    if scale is None:
+        adc_scale = None
+    else:
+        adc_scale = _default_adc_scale.copy().update({"ref_voltage": scale})
+
+    example = config_override(CONFIG_DIR / "stream_daq_test_200px.yml", {"adc_scaling": adc_scale})
     instance_config = StreamDevConfig.from_yaml(example)
 
     battery_voltage_adc = 200
@@ -56,9 +73,25 @@ def test_adc_scaling():
     )
     instance_header.set_adc_scaling(instance_config.adc_scale)
 
-    battery_voltage = battery_voltage_adc / 2 ** instance_config.adc_scale.bitdepth * instance_config.adc_scale.ref_voltage * instance_config.adc_scale.battery_div_factor
+    if scale is None:
+        with pytest.raises(ValueError):
+            _ = instance_header.battery_voltage
+            _ = instance_header.input_voltage
 
-    input_voltage = input_voltage_adc / 2 ** instance_config.adc_scale.bitdepth * instance_config.adc_scale.ref_voltage * instance_config.adc_scale.vin_div_factor
+    else:
+        battery_voltage = (
+            battery_voltage_adc
+            / 2**instance_config.adc_scale.bitdepth
+            * scale
+            * instance_config.adc_scale.battery_div_factor
+        )
 
-    assert instance_header.battery_voltage == battery_voltage
-    assert instance_header.input_voltage == input_voltage
+        input_voltage = (
+            input_voltage_adc
+            / 2**instance_config.adc_scale.bitdepth
+            * scale
+            * instance_config.adc_scale.vin_div_factor
+        )
+
+        assert instance_header.battery_voltage == battery_voltage
+        assert instance_header.input_voltage == input_voltage

--- a/tests/test_models/test_model_stream.py
+++ b/tests/test_models/test_model_stream.py
@@ -42,7 +42,7 @@ _default_adc_scale = {
 }
 
 
-@pytest.mark.parametrize("scale", [None, 1, 2, _default_adc_scale["ref_voltage"]])
+@pytest.mark.parametrize("scale", [1, 2, _default_adc_scale["ref_voltage"]])
 def test_adc_scaling(scale, config_override):
     """
     Test that the ADC scaling factors are correctly parsed
@@ -50,9 +50,10 @@ def test_adc_scaling(scale, config_override):
     if scale is None:
         adc_scale = None
     else:
-        adc_scale = _default_adc_scale.copy().update({"ref_voltage": scale})
+        adc_scale = _default_adc_scale.copy()
+        adc_scale.update({"ref_voltage": scale})
 
-    example = config_override(CONFIG_DIR / "stream_daq_test_200px.yml", {"adc_scaling": adc_scale})
+    example = config_override(CONFIG_DIR / "stream_daq_test_200px.yml", {"adc_scale": adc_scale})
     instance_config = StreamDevConfig.from_yaml(example)
 
     battery_voltage_adc = 200

--- a/tests/test_models/test_model_stream.py
+++ b/tests/test_models/test_model_stream.py
@@ -1,7 +1,7 @@
 import pytest
 
 from miniscope_io import DEVICE_DIR
-from miniscope_io.models.stream import StreamDevConfig
+from miniscope_io.models.stream import StreamDevConfig, StreamBufferHeader
 
 from ..conftest import CONFIG_DIR
 
@@ -31,7 +31,34 @@ def test_absolute_bitstream():
     assert instance.bitstream.is_absolute()
     assert str(instance.bitstream).startswith(str(DEVICE_DIR))
 
+def test_adc_scaling():
+    """
+    Test that the ADC scaling factors are correctly parsed
+    """
+    example = CONFIG_DIR / 'stream_daq_test_200px.yml'
+    instance_config = StreamDevConfig.from_yaml(example)
 
+    battery_voltage_adc = 200
+    input_voltage_adc = 250
 
+    instance_header = StreamBufferHeader(
+        linked_list=0,
+        frame_num=0,
+        buffer_count=0,
+        frame_buffer_count=0,
+        write_buffer_count=0,
+        dropped_buffer_count=0,
+        timestamp=0,
+        pixel_count=0,
+        write_timestamp=0,
+        battery_voltage_adc=battery_voltage_adc,
+        input_voltage_adc=input_voltage_adc,
+    )
+    instance_header.set_adc_scaling(instance_config.adc_scale)
 
+    battery_voltage = battery_voltage_adc / 2 ** instance_config.adc_scale.bitdepth * instance_config.adc_scale.ref_voltage * instance_config.adc_scale.battery_div_factor
 
+    input_voltage = input_voltage_adc / 2 ** instance_config.adc_scale.bitdepth * instance_config.adc_scale.ref_voltage * instance_config.adc_scale.vin_div_factor
+
+    assert instance_header.battery_voltage == battery_voltage
+    assert instance_header.input_voltage == input_voltage


### PR DESCRIPTION
I'm doing this quick PR because I needed it for hardware experiments. This PR is just for converting ADC to voltage in the `StreamBufferHeader` model using the YAML device config. I think I'll update to `v0.4.1` combined with #41 if this looks quick enough.