### PR TITLE
[ci] Add readthedocs preview links to PRs

### DIFF
--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -1,0 +1,16 @@
+name: readthedocs PR Preview links
+on:
+  pull_request_target:
+    types:
+      - opened
+
+permissions:
+  pull-requests: write
+
+jobs:
+  documentation-links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: readthedocs/actions/preview@v1
+        with:
+          project-slug: "miniscope-io"


### PR DESCRIPTION
I'm gonna :self-high-five: this one, all it is doing is adding a CI action that adds a link to the readthedocs build for a PR to the OP issue when a PR is opened:

see:
https://github.com/readthedocs/actions/tree/v1/preview