### PR TITLE
use dynamic versioning

### DIFF
--- a/miniscope_io/__init__.py
+++ b/miniscope_io/__init__.py
@@ -2,6 +2,7 @@
 I/O SDK for UCLA Miniscopes
 """
 
+from importlib import metadata
 from pathlib import Path
 
 from miniscope_io.io import SDCard
@@ -21,3 +22,8 @@ __all__ = [
     "SDCard",
     "init_logger",
 ]
+
+try:
+    __version__ = metadata.version("miniscope_io")
+except metadata.PackageNotFoundError:  # pragma: nocover
+    __version__ = "0.0.0"

--- a/miniscope_io/__init__.py
+++ b/miniscope_io/__init__.py
@@ -26,4 +26,4 @@ __all__ = [
 try:
     __version__ = metadata.version("miniscope_io")
 except metadata.PackageNotFoundError:  # pragma: nocover
-    __version__ = "0.0.0"
+    __version__ = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,13 @@
 [project]
 name = "miniscope_io"
-version = "0.5.0"
 description = "Generic I/O for miniscopes"
 authors = [
     {name = "sneakers-the-rat", email = "sneakers-the-rat@protonmail.com"},
     {name = "t-sasatani", email = "sasatani.dev@gmail.com"},
 ]
 license = {text = "AGPL-3.0"}
+dynamic = ["version"]
+
 requires-python = "<4.0,>=3.9"
 dependencies = [
     "opencv-python>=4.7.0.72",
@@ -92,6 +93,11 @@ format.composite = [
 
 [tool.pdm.build]
 includes = ["miniscope_io"]
+
+[tool.pdm.version]
+source = "scm"
+tag_filter = "v*"
+tag_regex = 'v(?P<version>([1-9][0-9]*!)?(0|[1-9][0-9]*)(\.(0|[1-9][0-9]*))*((a|b|c|rc)(0|[1-9][0-9]*))?(\.post(0|[1-9][0-9]*))?(\.dev(0|[1-9][0-9]*))?$)$'
 
 [build-system]
 requires = ["pdm-backend"]


### PR DESCRIPTION
instead of handcoding the version, let's just use the git tags. this is en route to continuous deployment where we just cut a new version by pushing a new tag. it will also let us give unambiguous version information for provenance sake when we start embedding version in configs and output data

- `v0.0.0`:  when you are on a clean checkout (nothing changed, nothing staged) of a commit with a tag with the pattern `v.*`, that is the version. i.e. when a CI/CD action is triggered by a new tag starting with v, that will be the version. We don't use tags for anything else atm so there shouldn't be a problem of accidentally making a non-version tag that starts with `v`, but in any case we'll deal with that in the cd action.
- `v0.0.0.dev{n}+{hash}` (e.g. `0.4.2.dev8+g56b32b7`) where `n` is the number of commits after the last version tag and `hash` is the short hash: when you are on a clean checkout (nothing changed, nothing stages) of a commit ***without*** a version tag. The `n` is computed relative to the closest tag in the commit history
- `v0.0.0.dev{n}+{hash}.d{time:%Y%m%d}` (e.g. ` 0.4.2.dev8+g56b32b7.d20241106`): when you are on a *dirty* commit with no version - aka you have uncommitted or unstaged changes in the repo.

also added `__version__` const as is outdated but still treasured tradition

see: https://backend.pdm-project.org/metadata/#dynamic-project-version

<!-- readthedocs-preview miniscope-io start -->
----
📚 Documentation preview 📚: https://miniscope-io--56.org.readthedocs.build/en/56/

<!-- readthedocs-preview miniscope-io end -->