### PR TITLE
Fix annoying pydantic warnings

### DIFF
--- a/miniscope_io/logging.py
+++ b/miniscope_io/logging.py
@@ -93,7 +93,7 @@ def _file_handler(
 def _rich_handler() -> RichHandler:
     rich_handler = RichHandler(rich_tracebacks=True, markup=True)
     rich_formatter = logging.Formatter(
-        "[bold green]\[%(name)s][/bold green] %(message)s",
+        r"[bold green]\[%(name)s][/bold green] %(message)s",
         datefmt="[%y-%m-%dT%H:%M:%S]",
     )
     rich_handler.setFormatter(rich_formatter)

--- a/miniscope_io/stream_daq.py
+++ b/miniscope_io/stream_daq.py
@@ -800,7 +800,7 @@ class StreamDaq:
                     self.logger.debug("Saving header metadata")
                     try:
                         self._buffered_writer.append(
-                            list(header.model_dump().values()) + [time.time()]
+                            list(header.model_dump(warnings=False).values()) + [time.time()]
                         )
                     except Exception as e:
                         self.logger.exception(f"Exception saving headers: \n{e}")

--- a/tests/test_stream_daq.py
+++ b/tests/test_stream_daq.py
@@ -123,6 +123,7 @@ def test_csv_output(tmp_path, default_streamdaq, write_metadata, caplog):
         default_streamdaq.capture(source="fpga", metadata=None, show_video=False)
         assert not output_csv.exists()
 
+
 # This is a helper function for test_continuous_and_termination() that is currently skipped
 """
 def capture_wrapper(default_streamdaq, source, show_video, continuous):
@@ -132,8 +133,10 @@ def capture_wrapper(default_streamdaq, source, show_video, continuous):
         pass # expected
 """
 
-@pytest.mark.skip("Needs to be implemented." 
-                  "Temporary skipped because tests fail in some OS (See GH actions).")
+
+@pytest.mark.skip(
+    "Needs to be implemented. Temporary skipped because tests fail in some OS (See GH actions)."
+)
 @pytest.mark.timeout(10)
 def test_continuous_and_termination(tmp_path, default_streamdaq):
     """
@@ -161,6 +164,7 @@ def test_continuous_and_termination(tmp_path, default_streamdaq):
     assert len(alive_processes) == 0
     """
     pass
+
 
 def test_metadata_plotting(tmp_path, default_streamdaq):
     """


### PR DESCRIPTION
Currently the test output is a total clusterfuck because of warnings emitted when writing the header data.

The warnings come because we're using `model_construct()` to create the header models, which skips the validation and coercion step, so we have numpy ints/floats instead of base python ints/floats. They serialize just fine, so it's safe to just ignore the warning there. 

Also fixed a warning from python thinking we're trying to escape ``'\['` instead of making a rich format string, so changed that to a raw string.

now there are no noisy warnings!