### PR TITLE
Test docs

### DIFF
--- a/.github/workflows/docs-test.yml
+++ b/.github/workflows/docs-test.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: "3.12"
           cache: "pip"

--- a/.github/workflows/docs-test.yml
+++ b/.github/workflows/docs-test.yml
@@ -1,0 +1,33 @@
+name: Build and test documentation
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  test_docs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Set up python
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: pip install -e .[docs] pytest-md
+
+      - name: Build docs
+        working-directory: docs
+        env:
+          SPHINXOPTS: "-W --keep-going"
+        run: pdm run make html

--- a/.github/workflows/docs-test.yml
+++ b/.github/workflows/docs-test.yml
@@ -30,4 +30,4 @@ jobs:
         working-directory: docs
         env:
           SPHINXOPTS: "-W --keep-going"
-        run: pdm run make html
+        run: make html

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,7 +41,6 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
 html_theme = "furo"
-html_static_path = ["_static"]
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),

--- a/miniscope_io/plots/headers.py
+++ b/miniscope_io/plots/headers.py
@@ -18,7 +18,7 @@ except ImportError:
     plt = None
 
 
-def buffer_count(headers: pd.DataFrame, ax: plt.Axes) -> plt.Axes:
+def buffer_count(headers: pd.DataFrame, ax: "plt.Axes") -> "plt.Axes":
     """
     Plot number of buffers by time
     """
@@ -32,7 +32,7 @@ def buffer_count(headers: pd.DataFrame, ax: plt.Axes) -> plt.Axes:
     return ax
 
 
-def dropped_buffers(headers: pd.DataFrame, ax: plt.Axes) -> plt.Axes:
+def dropped_buffers(headers: pd.DataFrame, ax: "plt.Axes") -> "plt.Axes":
     """
     Plot number of buffers by time
     """
@@ -42,7 +42,7 @@ def dropped_buffers(headers: pd.DataFrame, ax: plt.Axes) -> plt.Axes:
     return ax
 
 
-def timestamps(headers: pd.DataFrame, ax: plt.Axes) -> plt.Axes:
+def timestamps(headers: pd.DataFrame, ax: "plt.Axes") -> "plt.Axes":
     """
     Plot frame number against time
     """
@@ -57,7 +57,7 @@ def timestamps(headers: pd.DataFrame, ax: plt.Axes) -> plt.Axes:
     return ax
 
 
-def battery_voltage(headers: pd.DataFrame, ax: plt.Axes) -> plt.Axes:
+def battery_voltage(headers: pd.DataFrame, ax: "plt.Axes") -> "plt.Axes":
     """
     Plot battery voltage against time
     """
@@ -70,7 +70,7 @@ def battery_voltage(headers: pd.DataFrame, ax: plt.Axes) -> plt.Axes:
 
 def plot_headers(
     headers: pd.DataFrame, size: Optional[Tuple[int, int]] = None
-) -> (plt.Figure, plt.Axes):
+) -> ("plt.Figure", "plt.Axes"):
     """
     Plot the headers (generated from :meth:`.Frame.to_df` )
 
@@ -151,7 +151,7 @@ class StreamPlotter:
 
     def _init_plot(
         self,
-    ) -> tuple[plt.Figure, dict[str, plt.Axes], dict[str, plt.Line2D]]:
+    ) -> tuple["plt.Figure", dict[str, "plt.Axes"], dict[str, "plt.Line2D"]]:
 
         # initialize matplotlib
         plt.ion()

--- a/miniscope_io/plots/headers.py
+++ b/miniscope_io/plots/headers.py
@@ -14,11 +14,8 @@ from miniscope_io.models.stream import StreamBufferHeader
 
 try:
     import matplotlib.pyplot as plt
-except ImportError as e:
-    raise ImportError(
-        "matplotlib is not a required dependency of miniscope-io, "
-        "install it with the miniscope-io[plot] extra or manually in your environment :)"
-    ) from e
+except ImportError:
+    plt = None
 
 
 def buffer_count(headers: pd.DataFrame, ax: plt.Axes) -> plt.Axes:
@@ -132,6 +129,13 @@ class StreamPlotter:
             history_length (int): Number of headers to plot
             update_ms (int): milliseconds between each plot update
         """
+        global plt
+        if plt is None:
+            raise ModuleNotFoundError(
+                "matplotlib is not a required dependency of miniscope-io, to use it, "
+                "install it manually or install miniscope-io with `pip install miniscope-io[plot]`"
+            )
+
         # If a single string is provided, convert it to a list with one element
         if isinstance(header_keys, str):
             header_keys = [header_keys]


### PR DESCRIPTION
Fix: https://github.com/Aharoni-Lab/miniscope-io/issues/71

To keep the documentation from being broken, let's test the docs - this action builds the docs and raises warnings as errors.

Error from documenting the CLI seems to have come from needing to have matplotlib installed to import anything, which shouldn't be the case - we want matplotlib to be optional bc it's heavy. So i changed that importerror to a check when one attempts to use the streamplotter instead

<!-- readthedocs-preview miniscope-io start -->
----
📚 Documentation preview 📚: https://miniscope-io--75.org.readthedocs.build/en/75/

<!-- readthedocs-preview miniscope-io end -->