### PR TITLE
Running MSUS at higher FPS

### DIFF
--- a/mio/data/config/gs/MSUS.yml
+++ b/mio/data/config/gs/MSUS.yml
@@ -37,7 +37,7 @@ header_len: 384 # 12 * 32 (in bits)
 buffer_block_length: 4  # 10 # originally 12 how many words per block length
 block_size: 3774 # 4012 # just buffer (header+data-header)
 num_buffers: 6 # 6 # (maybe change to 10 num of data buffers inside mcu
-dummy_words: 12 # num of dummy words before header file
+dummy_words: 12 # 12 # num of dummy words before header file
 
 # Flags to flip bit/byte order when recovering headers and data. See model document for details.
 reverse_header_bits: False # False

--- a/mio/data/config/gs/MSUS.yml
+++ b/mio/data/config/gs/MSUS.yml
@@ -29,12 +29,12 @@ preamble: 0x78563412 # new preamble
 frame_width: 328 # 271 # 320 # 320 328 * 12 PP, with the extra 8 coming from the start_of_frame sequence
 frame_height: 271 # 320 # lines total original 320
 pix_depth: 12 #  pixel depth, or, pixel period, original: 10
-max_pixels_per_buffer: 10000 # original: 10000
+max_pixels_per_buffer: 9840 #  original: 10000
 
 # Buffer data format. These have to match the firmware value
 header_len: 384 # 12 * 32 (in bits)
 buffer_block_length: 4  # 10 # originally 12 how many words per block length
-block_size:  3774 # 4012 # just buffer (header+data-header)
+block_size:  3714 # 3774 # 4012 # just buffer (header+data-header)
 num_buffers: 6 # 6 # (maybe change to 10 num of data buffers inside mcu
 dummy_words: 12 # 12 # num of dummy words before header file
 

--- a/mio/data/config/gs/MSUS.yml
+++ b/mio/data/config/gs/MSUS.yml
@@ -26,15 +26,15 @@ preamble: 0x78563412 # new preamble
 # Incoming Pre-Processed Image format. 
 # StreamDaq will calculate buffer size, etc. based on these parameters
 # this should be 320x320x10
-frame_width: 320 # 320 328 * 12 PP, with the extra 8 coming from the start_of_frame sequence
-frame_height: 328 # lines total original 320
-pix_depth: 8 #  pixel depth, or, pixel period, original: 10
+frame_width: 328 # 271 # 320 # 320 328 * 12 PP, with the extra 8 coming from the start_of_frame sequence
+frame_height: 271 # 320 # lines total original 320
+pix_depth: 12 #  pixel depth, or, pixel period, original: 10
 max_pixels_per_buffer: 10000 # original: 10000
 
 # Buffer data format. These have to match the firmware value
 header_len: 384 # 12 * 32 (in bits)
 buffer_block_length: 4  # 10 # originally 12 how many words per block length
-block_size:  2500 # 3774 # 4012 # just buffer (header+data-header)
+block_size:  3774 # 4012 # just buffer (header+data-header)
 num_buffers: 6 # 6 # (maybe change to 10 num of data buffers inside mcu
 dummy_words: 12 # 12 # num of dummy words before header file
 

--- a/mio/data/config/gs/MSUS.yml
+++ b/mio/data/config/gs/MSUS.yml
@@ -11,8 +11,8 @@ device: "OK"
 # bitstream: "XEM7310-A75/USBInterface-3_03mhz-J2_2-3v3-IEEE.bit"
 # bitstream: "XEM7310-A75/USBInterface-5mhz-J2_2-3v3-IEEE.bit"
 # bitstream: "XEM7310-A75/USBInterface-6_67mhz-J2_2-3v3-IEEE.bit"
-bitstream: "XEM7310-A75/USBInterface-8_33mhz-J2_2-3v3-IEEE.bit" # original
-# bitstream: "XEM7310-A75/USBInterface-12_5mhz-J2_2-3v3-IEEE.bit"
+# bitstream: "XEM7310-A75/USBInterface-8_33mhz-J2_2-3v3-IEEE.bit" # original
+bitstream: "XEM7310-A75/USBInterface-12_5mhz-J2_2-3v3-IEEE.bit"
 # bitstream: "XEM7310-A75/USBInterface-16_67mhz-J2_2-3v3-IEEE.bit"
 # bitstream: "XEM7310-A75/USBInterface-20mhz-J2_2-3v3-IEEE.bit" 
 

--- a/mio/data/config/gs/MSUS.yml
+++ b/mio/data/config/gs/MSUS.yml
@@ -11,8 +11,8 @@ device: "OK"
 # bitstream: "XEM7310-A75/USBInterface-3_03mhz-J2_2-3v3-IEEE.bit"
 # bitstream: "XEM7310-A75/USBInterface-5mhz-J2_2-3v3-IEEE.bit"
 # bitstream: "XEM7310-A75/USBInterface-6_67mhz-J2_2-3v3-IEEE.bit"
-# bitstream: "XEM7310-A75/USBInterface-8_33mhz-J2_2-3v3-IEEE.bit" # original
-bitstream: "XEM7310-A75/USBInterface-12_5mhz-J2_2-3v3-IEEE.bit"
+bitstream: "XEM7310-A75/USBInterface-8_33mhz-J2_2-3v3-IEEE.bit" # original
+# bitstream: "XEM7310-A75/USBInterface-12_5mhz-J2_2-3v3-IEEE.bit"
 # bitstream: "XEM7310-A75/USBInterface-16_67mhz-J2_2-3v3-IEEE.bit"
 # bitstream: "XEM7310-A75/USBInterface-20mhz-J2_2-3v3-IEEE.bit" 
 
@@ -26,15 +26,15 @@ preamble: 0x78563412 # new preamble
 # Incoming Pre-Processed Image format. 
 # StreamDaq will calculate buffer size, etc. based on these parameters
 # this should be 320x320x10
-frame_width: 320  # 328 * 12 PP, with the extra 8 coming from the start_of_frame sequence
-frame_height: 320 # 320 lines total
-pix_depth: 10 # pixel depth, or, pixel period
-max_pixels_per_buffer: 10000
+frame_width: 320 # 320 328 * 12 PP, with the extra 8 coming from the start_of_frame sequence
+frame_height: 328 # lines total original 320
+pix_depth: 8 #  pixel depth, or, pixel period, original: 10
+max_pixels_per_buffer: 10000 # original: 10000
 
 # Buffer data format. These have to match the firmware value
 header_len: 384 # 12 * 32 (in bits)
 buffer_block_length: 4  # 10 # originally 12 how many words per block length
-block_size: 3774 # 4012 # just buffer (header+data-header)
+block_size:  2500 # 3774 # 4012 # just buffer (header+data-header)
 num_buffers: 6 # 6 # (maybe change to 10 num of data buffers inside mcu
 dummy_words: 12 # 12 # num of dummy words before header file
 

--- a/mio/data/config/gs/MSUS.yml
+++ b/mio/data/config/gs/MSUS.yml
@@ -21,7 +21,6 @@ port: null
 baudrate: null
 
 # Preamble for each data buffer.
-# preamble: 0x12345678 # original preamble
 preamble: 0x78563412 # new preamble
 
 # Incoming Pre-Processed Image format. 

--- a/mio/data/config/gs/MSUS.yml
+++ b/mio/data/config/gs/MSUS.yml
@@ -26,8 +26,8 @@ preamble: 0x78563412 # new preamble
 # Incoming Pre-Processed Image format. 
 # StreamDaq will calculate buffer size, etc. based on these parameters
 # this should be 320x320x10
-frame_width: 328 # 271 # 320 # 320 328 * 12 PP, with the extra 8 coming from the start_of_frame sequence
-frame_height: 271 # 320 # lines total original 320
+frame_width: 271 # 320 # 320 328 * 12 PP, with the extra 8 coming from the start_of_frame sequence
+frame_height: 320 # 320 # lines total original 320
 pix_depth: 12 #  pixel depth, or, pixel period, original: 10
 max_pixels_per_buffer: 9840 #  original: 10000
 

--- a/mio/data/config/gs/MSUS.yml
+++ b/mio/data/config/gs/MSUS.yml
@@ -11,10 +11,10 @@ device: "OK"
 # bitstream: "XEM7310-A75/USBInterface-3_03mhz-J2_2-3v3-IEEE.bit"
 # bitstream: "XEM7310-A75/USBInterface-5mhz-J2_2-3v3-IEEE.bit"
 # bitstream: "XEM7310-A75/USBInterface-6_67mhz-J2_2-3v3-IEEE.bit"
-bitstream: "XEM7310-A75/USBInterface-8_33mhz-J2_2-3v3-IEEE.bit" # original
-# bitstream: "XEM7310-A75/USBInterface-12_5mhz-J2_2-3v3-IEEE.bit"
+# bitstream: "XEM7310-A75/USBInterface-8_33mhz-J2_2-3v3-IEEE.bit" # original
+bitstream: "XEM7310-A75/USBInterface-12_5mhz-J2_2-3v3-IEEE.bit"
 # bitstream: "XEM7310-A75/USBInterface-16_67mhz-J2_2-3v3-IEEE.bit"
-# bitstream: "XEM7310-A75/USBInterface-20mhz-J2_2-3v3-IEEE.bit" 
+# bitstream: "XEM7310-A75/USBInterface-20mhz-J2_2-3v3-IEEE.bit"
 
 # COM port and baud rate is only required for UART mode
 port: null
@@ -23,18 +23,18 @@ baudrate: null
 # Preamble for each data buffer.
 preamble: 0x78563412 # new preamble
 
-# Incoming Pre-Processed Image format. 
+# Incoming Pre-Processed Image format.
 # StreamDaq will calculate buffer size, etc. based on these parameters
 # this should be 320x320x10
-frame_width: 271 # 320 # 320 328 * 12 PP, with the extra 8 coming from the start_of_frame sequence
-frame_height: 320 # 320 # lines total original 320
-pix_depth: 12 #  pixel depth, or, pixel period, original: 10
-max_pixels_per_buffer: 9840 #  original: 10000
+frame_width: 320  # 328 * 12 PP, with the extra 8 coming from the start_of_frame sequence
+frame_height: 320 # 320 lines total
+pix_depth: 10 # pixel depth, or, pixel period
+max_pixels_per_buffer: 10000
 
 # Buffer data format. These have to match the firmware value
 header_len: 384 # 12 * 32 (in bits)
 buffer_block_length: 4  # 10 # originally 12 how many words per block length
-block_size:  3714 # 3774 # 4012 # just buffer (header+data-header)
+block_size: 3774 # 4012 # just buffer (header+data-header)
 num_buffers: 6 # 6 # (maybe change to 10 num of data buffers inside mcu
 dummy_words: 12 # 12 # num of dummy words before header file
 

--- a/mio/data/config/gs/MSUS.yml
+++ b/mio/data/config/gs/MSUS.yml
@@ -11,8 +11,8 @@ device: "OK"
 # bitstream: "XEM7310-A75/USBInterface-3_03mhz-J2_2-3v3-IEEE.bit"
 # bitstream: "XEM7310-A75/USBInterface-5mhz-J2_2-3v3-IEEE.bit"
 # bitstream: "XEM7310-A75/USBInterface-6_67mhz-J2_2-3v3-IEEE.bit"
-# bitstream: "XEM7310-A75/USBInterface-8_33mhz-J2_2-3v3-IEEE.bit" # original
-bitstream: "XEM7310-A75/USBInterface-12_5mhz-J2_2-3v3-IEEE.bit"
+bitstream: "XEM7310-A75/USBInterface-8_33mhz-J2_2-3v3-IEEE.bit" # original
+# bitstream: "XEM7310-A75/USBInterface-12_5mhz-J2_2-3v3-IEEE.bit"
 # bitstream: "XEM7310-A75/USBInterface-16_67mhz-J2_2-3v3-IEEE.bit"
 # bitstream: "XEM7310-A75/USBInterface-20mhz-J2_2-3v3-IEEE.bit" 
 

--- a/mio/devices/gs/config.py
+++ b/mio/devices/gs/config.py
@@ -25,7 +25,7 @@ class GSDevConfig(StreamDevConfig):
     def pix_depth_input(self) -> int:
         """12 bit raw processed to 10 bit pixel values"""
         # return self.pix_depth + 2
-        return self.pix_depth
+        return self.pix_depth + 2
 
     @property
     def buffer_npix(self) -> list[int]:

--- a/mio/devices/gs/config.py
+++ b/mio/devices/gs/config.py
@@ -10,7 +10,7 @@ from mio.models.stream import StreamDevConfig
 class GSDevConfig(StreamDevConfig):
     """Device config for an unknown, mystery microscope"""
 
-    pix_depth: int = 12
+    pix_depth: int = 8 # 12 originally
     max_pixels_per_buffer: int = 10000
 
     model_config = ConfigDict(validate_default=True)
@@ -18,12 +18,14 @@ class GSDevConfig(StreamDevConfig):
     @property
     def frame_width_input(self) -> int:
         """8 (12 bit) alignment columns removed from 320 rows of imaging data"""
+        # return self.frame_width + 8
         return self.frame_width + 8
 
     @property
     def pix_depth_input(self) -> int:
         """12 bit raw processed to 10 bit pixel values"""
-        return self.pix_depth + 2
+        # return self.pix_depth + 2
+        return self.pix_depth
 
     @property
     def buffer_npix(self) -> list[int]:

--- a/mio/devices/gs/config.py
+++ b/mio/devices/gs/config.py
@@ -10,7 +10,7 @@ from mio.models.stream import StreamDevConfig
 class GSDevConfig(StreamDevConfig):
     """Device config for an unknown, mystery microscope"""
 
-    pix_depth: int = 8 # 12 originally
+    pix_depth: int = 12 # 12 originally
     max_pixels_per_buffer: int = 10000
 
     model_config = ConfigDict(validate_default=True)

--- a/mio/devices/gs/daq.py
+++ b/mio/devices/gs/daq.py
@@ -22,7 +22,8 @@ def format_frame(frame_data: list[np.ndarray], config: GSDevConfig) -> np.ndarra
     Convert a list of 1D pixel arrays into a full frame, stripping the leading "training" pixels
     """
     pixels = np.concatenate(frame_data)
-    frame = pixels.reshape((config.frame_height, config.frame_width_input))
+    frame = pixels.reshape((config.frame_height, config.frame_width_input)) # original
+
 
     # strip training pixels
     frame = frame[:, 8:]

--- a/mio/devices/gs/daq.py
+++ b/mio/devices/gs/daq.py
@@ -10,10 +10,10 @@ import numpy as np
 from mio import init_logger
 from mio.devices.gs.config import GSDevConfig
 from mio.devices.gs.header import GSBufferHeader, GSBufferHeaderFormat
-from mio.io import BufferedCSVWriter
 from mio.plots.headers import StreamPlotter
 from mio.stream_daq import StreamDaq
 from mio.types import ConfigSource
+from mio.io import BufferedCSVWriter, VideoWriter
 
 
 # testing here:
@@ -83,7 +83,7 @@ class GSStreamDaq(StreamDaq):
         image: np.ndarray,
         header_list: list[GSBufferHeaderFormat],
         show_video: bool,
-        writer: Optional[cv2.VideoWriter],
+        writer: Optional[VideoWriter],
         show_metadata: bool,
         metadata: Optional[Path] = None,
     ) -> None:
@@ -123,6 +123,6 @@ class GSStreamDaq(StreamDaq):
         if writer:
             try:
                 picture = cv2.cvtColor(image, cv2.COLOR_GRAY2BGR)  # If your image is grayscale
-                writer.write(picture)
+                writer.write_frame(picture)
             except cv2.error as e:
                 self.logger.exception(f"Exception writing frame: {e}")

--- a/mio/devices/gs/daq.py
+++ b/mio/devices/gs/daq.py
@@ -23,6 +23,7 @@ def format_frame(frame_data: list[np.ndarray], config: GSDevConfig) -> np.ndarra
     """
     pixels = np.concatenate(frame_data)
     frame = pixels.reshape((config.frame_height, config.frame_width_input)) # original
+    # frame = pixels.reshape(320, 271) # original
 
 
     # strip training pixels

--- a/mio/devices/gs/header.py
+++ b/mio/devices/gs/header.py
@@ -25,22 +25,24 @@ def buffer_to_array(buffer: bytes) -> np.ndarray:
 
     Strip the pads, and return a 16-bit ndarray
     """
-    # convert to a binary array
+    # convert to a binary array 8 at a time
     binary_data = np.unpackbits(np.frombuffer(buffer, dtype=np.uint8))
-    # reshape to be n x 12
+
+    # reshape to a n x 12
     pixel_cols = binary_data.reshape((-1, 12))
 
     # remove padding pixels (12 bit x n --> 10 bit x n)
     stripped = pixel_cols[:, 1:-1]
 
     # Cast to 16 bit ndarray
-    padded = np.pad(stripped, ((0, 0), (6, 0)), mode="constant", constant_values=0)
-    packed_16bit = np.packbits(padded, axis=1).view(np.uint16).byteswap()
-    # breakpoint()
+    # padded = np.pad(stripped, ((0, 0), (6, 0)), mode="constant", constant_values=0)
+    # packed_16bit = np.packbits(padded, axis=1).view(np.uint16).byteswap()
     # return packed_16bit.flatten()
 
-    stripped_8bit = stripped[:, :-2]
+    # cast to an 8 bit ndarray
+    stripped_8bit = stripped[:, :-2] # current
     packed_8bit =  np.packbits(stripped_8bit, axis=1).flatten()
+
     return packed_8bit
 
 

--- a/mio/devices/gs/header.py
+++ b/mio/devices/gs/header.py
@@ -36,8 +36,13 @@ def buffer_to_array(buffer: bytes) -> np.ndarray:
     # Cast to 16 bit ndarray
     padded = np.pad(stripped, ((0, 0), (6, 0)), mode="constant", constant_values=0)
     packed_16bit = np.packbits(padded, axis=1).view(np.uint16).byteswap()
+    # breakpoint()
+    # return packed_16bit.flatten()
 
-    return packed_16bit.flatten()
+    stripped_8bit = stripped[:, :-2]
+    packed_8bit =  np.packbits(stripped_8bit, axis=1).flatten()
+    return packed_8bit
+
 
 
 class GSBufferHeader(StreamBufferHeader):

--- a/mio/devices/gs/header.py
+++ b/mio/devices/gs/header.py
@@ -36,8 +36,8 @@ def buffer_to_array(buffer: bytes) -> np.ndarray:
     stripped = pixel_cols[:, 1:-1]
 
     # Cast to 16 bit ndarray
-    # padded = np.pad(stripped, ((0, 0), (6, 0)), mode="constant", constant_values=0)
-    # packed_16bit = np.packbits(padded, axis=1).view(np.uint16).byteswap()
+    padded = np.pad(stripped, ((0, 0), (6, 0)), mode="constant", constant_values=0)
+    packed_16bit = np.packbits(padded, axis=1).view(np.uint16).byteswap()
     # return packed_16bit.flatten()
 
     # cast to an 8 bit ndarray
@@ -46,7 +46,12 @@ def buffer_to_array(buffer: bytes) -> np.ndarray:
 
     return packed_8bit
 
+def buffer_to_array2(buffer: bytes) -> np.ndarray:
+    """
+    Just processing the buffer without removing anuthing
 
+    """
+    return np.frombuffer(buffer, dtype=np.uint8)
 
 class GSBufferHeader(StreamBufferHeader):
     """
@@ -77,9 +82,11 @@ class GSBufferHeader(StreamBufferHeader):
         header_array = np.frombuffer(buffer[header_start:header_end], dtype=np.uint32)
         header = cls.from_format(header_array, header_fmt, construct=True)
         dummy_len = config.dummy_words * 4
-        payload = buffer_to_array(
-            buffer[header_end:-dummy_len]
-        )  # ignoring the last 384 bits, can change after dummy is detected
+
+        # payload = buffer_to_array(buffer[header_end:-384])   ignoring the last 384 bits, can change after dummy is detected
+        payload = buffer_to_array2(buffer[header_end:])
+
+        print(len(payload))
         return header, payload
 
 

--- a/mio/devices/gs/header.py
+++ b/mio/devices/gs/header.py
@@ -38,13 +38,13 @@ def buffer_to_array(buffer: bytes) -> np.ndarray:
     stripped = pixel_cols[:, 1:-1]
 
     # Cast to 16 bit ndarray
-    padded = np.pad(stripped, ((0, 0), (6, 0)), mode="constant", constant_values=0)
-    packed_16bit = np.packbits(padded, axis=1).view(np.uint16).byteswap()
+    # padded = np.pad(stripped, ((0, 0), (6, 0)), mode="constant", constant_values=0)
+    # packed_16bit = np.packbits(padded, axis=1).view(np.uint16).byteswap()
     # return packed_16bit.flatten()
 
     # cast to an 8 bit ndarray
-    stripped_8bit = packed_16bit[:, :-2] # current
-    packed_8bit =  np.packbits(stripped_8bit, axis=1).flatten()
+    stripped_8bit = stripped[:, :-2]  # current
+    packed_8bit = np.packbits(stripped_8bit, axis=1).flatten()
 
     return packed_8bit
 
@@ -69,7 +69,7 @@ def buffer_to_array2(buffer: bytes) -> np.ndarray:
 
     return packed_8bit
 
-#     return np.frombuffer(buffer, dtype=np.uint8) # this is the line for fully processed
+#     return np.frombuffer(buffer, dtype=np.uint8) # this is the line for on board processing
 
 class GSBufferHeader(StreamBufferHeader):
     """
@@ -101,8 +101,8 @@ class GSBufferHeader(StreamBufferHeader):
         header = cls.from_format(header_array, header_fmt, construct=True)
         dummy_len = config.dummy_words * 4
 
-        # payload = buffer_to_array(buffer[header_end:-384]) #  ignoring the last 384 bits, can change after dummy is detected
-        payload = buffer_to_array2(buffer[header_end:])
+        payload = buffer_to_array(buffer[header_end:-384]) #  ignoring the last 384 bits, can change after dummy is detected
+        # payload = buffer_to_array2(buffer[header_end:-384])
         print(len(payload))
         return header, payload
 

--- a/mio/devices/gs/header.py
+++ b/mio/devices/gs/header.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     from mio.devices.gs.config import GSDevConfig
 
 
+
 def buffer_to_array(buffer: bytes) -> np.ndarray:
     """
     Given the GS's "12-bit" pixel format,
@@ -37,8 +38,8 @@ def buffer_to_array(buffer: bytes) -> np.ndarray:
     stripped = pixel_cols[:, 1:-1]
 
     # Cast to 16 bit ndarray
-    padded = np.pad(stripped, ((0, 0), (6, 0)), mode="constant", constant_values=0)
-    packed_16bit = np.packbits(padded, axis=1).view(np.uint16).byteswap()
+    # padded = np.pad(stripped, ((0, 0), (6, 0)), mode="constant", constant_values=0)
+    # packed_16bit = np.packbits(padded, axis=1).view(np.uint16).byteswap()
     # return packed_16bit.flatten()
 
     # cast to an 8 bit ndarray

--- a/mio/devices/gs/header.py
+++ b/mio/devices/gs/header.py
@@ -24,11 +24,12 @@ def buffer_to_array(buffer: bytes) -> np.ndarray:
     e.g. (``1xxxxxxxxxx0``)
 
     Strip the pads, and return a 16-bit ndarray
+
     """
     # convert to a binary array 8 at a time
     binary_data = np.unpackbits(np.frombuffer(buffer, dtype=np.uint8))
 
-    # reshape to a n x 12
+    # rehape to a n x 12
     pixel_cols = binary_data.reshape((-1, 12))
 
     # remove padding pixels (12 bit x n --> 10 bit x n)

--- a/mio/devices/gs/header.py
+++ b/mio/devices/gs/header.py
@@ -3,6 +3,7 @@
 import sys
 from typing import TYPE_CHECKING
 
+
 if sys.version_info >= (3, 11):
     from typing import Self
 else:
@@ -48,7 +49,7 @@ def buffer_to_array(buffer: bytes) -> np.ndarray:
 
 def buffer_to_array2(buffer: bytes) -> np.ndarray:
     """
-    Just processing the buffer without removing anuthing
+    Just processing the buffer without removing anything
 
     """
     return np.frombuffer(buffer, dtype=np.uint8)
@@ -83,9 +84,8 @@ class GSBufferHeader(StreamBufferHeader):
         header = cls.from_format(header_array, header_fmt, construct=True)
         dummy_len = config.dummy_words * 4
 
-        # payload = buffer_to_array(buffer[header_end:-384])   ignoring the last 384 bits, can change after dummy is detected
-        payload = buffer_to_array2(buffer[header_end:])
-
+        payload = buffer_to_array(buffer[header_end:-384]) #  ignoring the last 384 bits, can change after dummy is detected
+        # payload = buffer_to_array2(buffer[header_end:-48])
         print(len(payload))
         return header, payload
 

--- a/mio/devices/gs/header.py
+++ b/mio/devices/gs/header.py
@@ -38,12 +38,12 @@ def buffer_to_array(buffer: bytes) -> np.ndarray:
     stripped = pixel_cols[:, 1:-1]
 
     # Cast to 16 bit ndarray
-    # padded = np.pad(stripped, ((0, 0), (6, 0)), mode="constant", constant_values=0)
-    # packed_16bit = np.packbits(padded, axis=1).view(np.uint16).byteswap()
+    padded = np.pad(stripped, ((0, 0), (6, 0)), mode="constant", constant_values=0)
+    packed_16bit = np.packbits(padded, axis=1).view(np.uint16).byteswap()
     # return packed_16bit.flatten()
 
     # cast to an 8 bit ndarray
-    stripped_8bit = stripped[:, :-2] # current
+    stripped_8bit = packed_16bit[:, :-2] # current
     packed_8bit =  np.packbits(stripped_8bit, axis=1).flatten()
 
     return packed_8bit

--- a/mio/devices/gs/header.py
+++ b/mio/devices/gs/header.py
@@ -53,7 +53,23 @@ def buffer_to_array2(buffer: bytes) -> np.ndarray:
     Just processing the buffer without removing anything
 
     """
-    return np.frombuffer(buffer, dtype=np.uint8)
+    # convert to a binary array 8 at a time
+    binary_data = np.unpackbits(np.frombuffer(buffer, dtype=np.uint8))
+    # reshape to a n x 12
+
+    pixel_cols = binary_data.reshape((-1, 12))
+
+    # remove padding pixels (12 bit x n --> 10 bit x n)
+    # Strip MSB and LSB if your format is 1[10-bit data]0
+    stripped = pixel_cols[:, 1:-1]  # Now 10-bit data
+
+    # Cast to 8 bit ndarray (keep top 8 bits of the 10-bit data)
+    stripped_8bit = stripped[:, :-2]  # Take first 8 bits, drop last 2
+    packed_8bit = np.packbits(stripped_8bit, axis=1).flatten()
+
+    return packed_8bit
+
+#     return np.frombuffer(buffer, dtype=np.uint8) # this is the line for fully processed
 
 class GSBufferHeader(StreamBufferHeader):
     """
@@ -85,8 +101,8 @@ class GSBufferHeader(StreamBufferHeader):
         header = cls.from_format(header_array, header_fmt, construct=True)
         dummy_len = config.dummy_words * 4
 
-        payload = buffer_to_array(buffer[header_end:-384]) #  ignoring the last 384 bits, can change after dummy is detected
-        # payload = buffer_to_array2(buffer[header_end:-48])
+        # payload = buffer_to_array(buffer[header_end:-384]) #  ignoring the last 384 bits, can change after dummy is detected
+        payload = buffer_to_array2(buffer[header_end:])
         print(len(payload))
         return header, payload
 

--- a/mio/stream_daq.py
+++ b/mio/stream_daq.py
@@ -183,7 +183,7 @@ class StreamDaq:
                 f"Frame {header.frame_num}; Buffer {header.buffer_count} "
                 f"(#{header.frame_buffer_count} in frame)\n"
                 f"Expected buffer data length: {expected_payload_size}, got data with shape "
-                f"{data.shape}.\nPadding to expected length",
+                f"{data.shape[0]}.\nPadding to expected length",
             )
 
         if data.shape[0] != expected_data_size:

--- a/mio/stream_daq.py
+++ b/mio/stream_daq.py
@@ -178,7 +178,7 @@ class StreamDaq:
         expected_data_size = expected_size_array[header.frame_buffer_count]
 
         # This validation is temporary. More info in todo above.
-        if data.shape[0] != expected_payload_size + self.config.dummy_words * 4:
+        if data.shape[0] != expected_payload_size:
             logger.warning(
                 f"Frame {header.frame_num}; Buffer {header.buffer_count} "
                 f"(#{header.frame_buffer_count} in frame)\n"

--- a/mio/stream_daq.py
+++ b/mio/stream_daq.py
@@ -178,7 +178,7 @@ class StreamDaq:
         expected_data_size = expected_size_array[header.frame_buffer_count]
 
         # This validation is temporary. More info in todo above.
-        if data.shape[0] != expected_payload_size:
+        if data.shape[0] != expected_payload_size + self.config.dummy_words * 4:
             logger.warning(
                 f"Frame {header.frame_num}; Buffer {header.buffer_count} "
                 f"(#{header.frame_buffer_count} in frame)\n"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,7 +121,7 @@ filterwarnings = [
 testpaths = [
     "tests"
 ]
-timeout = 60
+timeout = 180
 
 [tool.coverage.run]
 omit = [

--- a/tests/data/config/mystery_scope.yml
+++ b/tests/data/config/mystery_scope.yml
@@ -35,7 +35,7 @@ header_len: 384 # 12 * 32 (in bits)
 buffer_block_length: 4 # originally 12 how many words per block length
 block_size: 3774 # 4012 # just buffer (header+data-header)
 num_buffers: 6 # 6 # (maybe change to 10 num of data buffers inside mcu
-dummy_words: 12 # num of dummy words before header file
+dummy_words: 12 # 12 # num of dummy words before header file
 
 # Flags to flip bit/byte order when recovering headers and data. See model document for details.
 reverse_header_bits: False # False

--- a/tests/data/config/mystery_scope.yml
+++ b/tests/data/config/mystery_scope.yml
@@ -9,8 +9,8 @@ device: "OK"
 # bitstream: "XEM7310-A75/USBInterface-3_03mhz-J2_2-3v3-IEEE.bit"
 # bitstream: "XEM7310-A75/USBInterface-5mhz-J2_2-3v3-IEEE.bit"
 # bitstream: "XEM7310-A75/USBInterface-6_67mhz-J2_2-3v3-IEEE.bit"
-bitstream: "XEM7310-A75/USBInterface-8_33mhz-J2_2-3v3-IEEE.bit" # original
-# bitstream: "XEM7310-A75/USBInterface-12_5mhz-J2_2-3v3-IEEE.bit"
+# bitstream: "XEM7310-A75/USBInterface-8_33mhz-J2_2-3v3-IEEE.bit" # original
+bitstream: "XEM7310-A75/USBInterface-12_5mhz-J2_2-3v3-IEEE.bit"
 # bitstream: "XEM7310-A75/USBInterface-16_67mhz-J2_2-3v3-IEEE.bit"
 # bitstream: "XEM7310-A75/USBInterface-20mhz-J2_2-3v3-IEEE.bit"
 

--- a/tests/data/config/mystery_scope.yml
+++ b/tests/data/config/mystery_scope.yml
@@ -9,8 +9,8 @@ device: "OK"
 # bitstream: "XEM7310-A75/USBInterface-3_03mhz-J2_2-3v3-IEEE.bit"
 # bitstream: "XEM7310-A75/USBInterface-5mhz-J2_2-3v3-IEEE.bit"
 # bitstream: "XEM7310-A75/USBInterface-6_67mhz-J2_2-3v3-IEEE.bit"
-# bitstream: "XEM7310-A75/USBInterface-8_33mhz-J2_2-3v3-IEEE.bit" # original
-bitstream: "XEM7310-A75/USBInterface-12_5mhz-J2_2-3v3-IEEE.bit"
+bitstream: "XEM7310-A75/USBInterface-8_33mhz-J2_2-3v3-IEEE.bit" # original
+# bitstream: "XEM7310-A75/USBInterface-12_5mhz-J2_2-3v3-IEEE.bit"
 # bitstream: "XEM7310-A75/USBInterface-16_67mhz-J2_2-3v3-IEEE.bit"
 # bitstream: "XEM7310-A75/USBInterface-20mhz-J2_2-3v3-IEEE.bit"
 

--- a/tests/test_gs/test_header.py
+++ b/tests/test_gs/test_header.py
@@ -6,7 +6,6 @@ import pytest
 from mio.devices.gs import testing
 from mio.devices.gs.header import GSBufferHeaderFormat, GSBufferHeader, buffer_to_array
 from mio.devices.gs.config import GSDevConfig
-from mio.devices.gs.daq import format_frame
 
 import numpy as np
 
@@ -80,3 +79,12 @@ def test_buffer_to_array():
     byte_sequence = bytes([0xC0, 0x1C, 0x01, 0xC0, 0x1C, 0x01])
     sequence_16bit = buffer_to_array(byte_sequence)
     assert np.array_equal(sequence_16bit, np.array([512, 512, 512, 512]))
+
+
+def test_buffer_to_array_8bit():
+    """Checking to see if a 12x4 (4 12 bit pixels) converts to a known value in our buffer_2_array fxn"""
+
+    byte_sequence = bytes([0xC0, 0x1C, 0x01, 0xC0, 0x1C, 0x01])
+    sequence_8bit = buffer_to_array(byte_sequence)
+    # assert np.array_equal(sequence_8bit, np.array([128, 128, 128, 128]))
+

--- a/tests/test_gs/test_header.py
+++ b/tests/test_gs/test_header.py
@@ -77,6 +77,8 @@ def test_buffer_to_array():
     """Checking to see if a 12x4 (4 12 bit pixels) converts to a known value in our buffer_2_array fxn"""
 
     byte_sequence = bytes([0xC0, 0x1C, 0x01, 0xC0, 0x1C, 0x01])
+    # byte_sequence = bytes([0x80, 0x08, 0x00, 0x80, 0x08, 0x00]) # assert np.array_equal(sequence_16bit, np.array([0, 0, 0, 0]))
+
     sequence_16bit = buffer_to_array(byte_sequence)
     assert np.array_equal(sequence_16bit, np.array([512, 512, 512, 512]))
 


### PR DESCRIPTION
*Working on getting higher FPS with NANEYE/MIO wired connection*

*Proof of Not-Working*
- posted below

*Current Status*
- Not working 12/08/25

*Proof that bug is fixed*
- Imaging at 12-13 MHz

Error message (output of device at 12 MHz)
[25-12-08T11:58:39] INFO     [mio.okDev] Connected to XEM7310-A75                           [[opalkelly.py:43](http://opalkelly.py:43/)](http://opalkelly.py:43/)
Process _buffer_to_frame:
Traceback (most recent call last):
File "C:\Users\hsemwal\AppData\Local\Programs\Python\Python313\Lib\multiprocessing\[[process.py](http://process.py/)](http://process.py/)", line 313, in _bootstrap
self.run()
~~~~~~~~^^
File "C:\Users\hsemwal\AppData\Local\Programs\Python\Python313\Lib\multiprocessing\[process.py](http://process.py/)", line 108, in run
self._target(*self._args, **self._kwargs)
~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "C:\Users\hsemwal\Documents\Github\mio\mio\stream_daq.py", line 326, in _buffer_to_frame
header_data, serial_buffer = self._parse_header(serial_buffer)
~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
File "C:\Users\hsemwal\Documents\Github\mio\mio\stream_daq.py", line 155, in _parse_header
header_data, payload = self.buffer_header_cls.from_buffer(
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
buffer, self.header_fmt, self.config
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
)
^
File "C:\Users\hsemwal\Documents\Github\mio\mio\devices\gs\[header.py](http://header.py/)", line 80, in from_buffer
payload = buffer_to_array(
buffer[header_end:-dummy_len]
)  # ignoring the last 384 bits, can change after dummy is detected
File "C:\Users\hsemwal\Documents\Github\mio\mio\devices\gs\[header.py](http://header.py/)", line 33, in buffer_to_array
pixel_cols = binary_data.reshape((-1, 12))
ValueError: cannot reshape array of size 15067280 into shape (12)
[25-12-08T11:58:52] WARNING  [mio.GSStreamDaq] Empty frame received, skipping.                   [daq.py:115](http://daq.py:115/)[25-12-08T11:58:57] WARNING  [mio.GSStreamDaq] Termination timeout: force terminating     stream_daq.py:662                             process _fpga_recv.

<!-- readthedocs-preview miniscope-io start -->
----
📚 Documentation preview 📚: https://miniscope-io--146.org.readthedocs.build/en/146/

<!-- readthedocs-preview miniscope-io end -->