### PR TITLE
Bugfix for passing noise_config

### DIFF
--- a/mio/cli/process.py
+++ b/mio/cli/process.py
@@ -380,7 +380,7 @@ def workflow(
         stitched = run_stitch(
             recordings,
             output_dir=output_dir,
-            noise_config=denoise_config_parsed,
+            noise_config=denoise_config_parsed.noise_patch,
             progress=True,
             force=force,
         )


### PR DESCRIPTION
A one-line patch. I think the fundamental problem is the broken terminology, but I guess we can leave this for later.

<!-- readthedocs-preview miniscope-io start -->
----
📚 Documentation preview 📚: https://miniscope-io--180.org.readthedocs.build/en/180/

<!-- readthedocs-preview miniscope-io end -->