### PR TITLE
convert typed tables to pandera

### DIFF
--- a/docs/api/devices/index.md
+++ b/docs/api/devices/index.md
@@ -6,4 +6,5 @@ High-level control of external devices like miniscopes and DAQs
 base
 sdcard
 stream
+tables
 ```

--- a/docs/api/devices/tables.md
+++ b/docs/api/devices/tables.md
@@ -1,0 +1,7 @@
+# tables
+
+```{eval-rst}
+.. automodule:: mio.devices.tables
+    :members:
+    :undoc-members:
+```

--- a/docs/api/models/index.md
+++ b/docs/api/models/index.md
@@ -7,14 +7,6 @@ needed for a specific acquisition class should be defined within that
 module, inheriting from the relevant parent class. Rule of thumb: 
 keep what is common common, and what is unique unique.
 
-
-
-```{eval-rst}
-.. automodule:: mio.models
-    :members:
-    :undoc-members:
-```
-
 ```{toctree}
 config
 data

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,6 +7,7 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 from importlib.metadata import version as _version
+import logging
 import sys
 from unittest.mock import Mock
 
@@ -86,3 +87,27 @@ autodoc_pydantic_model_show_json_error_strategy = "coerce"
 
 # todo
 todo_include_todos = True
+
+
+class FuckTheSphinxFiltersFilter(logging.Filter):
+    """
+    A filter that goes like "fuck the sphinx logging filters that ignores our warning filters"
+
+    Use this whenever there are warnings that cause CI to fail but you can't actually
+    do normal python things to suppress the warnings because
+    """
+
+    def filter(self, record: logging.LogRecord):
+        # the pandera Config thing gets indexed multiple times but we actually don't care!
+        if (
+            hasattr(record, "getMessage")
+            and "pandera.api.dataframe.model.Config" in record.getMessage()
+        ):
+            return False
+
+        return True
+
+
+def setup(app):
+    logger = logging.getLogger("sphinx")
+    logger.filters.insert(0, FuckTheSphinxFiltersFilter())

--- a/mio/devices/base/headers.py
+++ b/mio/devices/base/headers.py
@@ -2,9 +2,11 @@
 
 import sys
 from collections.abc import Sequence
-from typing import ClassVar
+from typing import Any, ClassVar
 
-from mio.models import Container
+import pandera.pandas as pa
+
+from mio.models import Container, Table
 
 if sys.version_info <= (3, 11):
     from typing_extensions import Self
@@ -14,7 +16,15 @@ else:
 
 class BufferHeader(Container):
     """
-    Container for the data stream's header, structured by :class:`.MetadataHeaderFormat`
+    Container for the data stream's header.
+
+    When converting from a sequence (like a numpy array or list of bytes),
+    the ``POSITIONS`` mapping is responsible for mapping sequential values to keys,
+    as different devices have the fields in different orders.
+
+    Not all keys must be set in ``POSITIONS`` -
+    extra keys may be provided e.g. at runtime while constructing the object
+    by passing ``**kwargs`` to :meth:`.from_sequence`
     """
 
     POSITIONS: ClassVar[dict[str, int]] = {
@@ -38,7 +48,9 @@ class BufferHeader(Container):
     write_timestamp: int
 
     @classmethod
-    def from_sequence(cls, vals: Sequence, construct: bool = False) -> Self:
+    def from_sequence(
+        cls, vals: Sequence, construct: bool = False, **kwargs: dict[str, Any]
+    ) -> Self:
         """
         Instantiate a buffer header from linearized values (eg. in an ndarray or list)
         and an associated format that tells us what index the model values are found
@@ -46,10 +58,11 @@ class BufferHeader(Container):
 
         Args:
             vals (list, :class:`numpy.ndarray` ): Indexable values to cast to the header model
-            format (:class:`.BufferHeaderFormat` ): Format used to index values
             construct (bool): If ``True`` , use :meth:`~pydantic.BaseModel.model_construct`
                 to create the model instance (ie. without validation, but faster).
                 Default: ``False``
+            **kwargs: Additional kwargs that are not specified in ``POSITIONS`` .
+                Values in ``kwargs`` overwrite those derived from ``vals`` .
 
         Returns:
             :class:`.BufferHeader`
@@ -60,7 +73,46 @@ class BufferHeader(Container):
             if header_index is not None:
                 header_data[hd] = vals[header_index]
 
+        header_data.update(kwargs)
+
         if construct:
             return cls.model_construct(**header_data)
         else:
             return cls(**header_data)
+
+    @classmethod
+    def csv_header_cols(cls) -> list[str]:
+        """
+        Return the standardized column names for CSV output.
+
+        This ensures consistent column ordering across all StreamBufferHeader instances
+        when writing to CSV files.
+
+        Args:
+            header_format: The StreamBufferHeaderFormat instance to get column ordering from
+
+        Returns:
+            list[str]: Column names in the order they should appear in CSV output
+        """
+        # Get the base header format columns (excluding internal fields)
+        header_items = sorted(cls.POSITIONS.items(), key=lambda x: x[1])
+        positioned_cols = [name for name, _ in header_items]
+
+        other_fields = [field for field in cls.model_fields if field not in positioned_cols]
+
+        return positioned_cols + other_fields
+
+
+class BufferTable(Table):
+    """Table corresponding to the BufferHeader record"""
+
+    _RECORD_MODEL = BufferHeader
+
+    linked_list: int = pa.Field(ge=0, coerce=True)
+    frame_num: int = pa.Field(ge=0, coerce=True)
+    buffer_count: int = pa.Field(ge=0, coerce=True)
+    frame_buffer_count: int = pa.Field(ge=0, coerce=True)
+    write_buffer_count: int = pa.Field(ge=0, coerce=True)
+    dropped_buffer_count: int = pa.Field(ge=0, coerce=True)
+    timestamp: int = pa.Field(ge=0, coerce=True)
+    write_timestamp: int = pa.Field(ge=0, coerce=True)

--- a/mio/devices/stream/__init__.py
+++ b/mio/devices/stream/__init__.py
@@ -5,15 +5,15 @@ like the miniscope zero and MSUS
 
 # ruff: noqa: I001
 
-from mio.devices.stream.headers import StreamBufferHeader, StreamDevRuntime, StreamPlotterConfig
-from mio.devices.stream.config import StreamDevConfig
+from mio.devices.stream.headers import StreamBufferHeader, StreamBufferTable
+from mio.devices.stream.config import StreamDevConfig, StreamDevRuntime
 from mio.devices.stream.device import StreamDevice, iter_buffers
 
 __all__ = [
     "StreamBufferHeader",
+    "StreamBufferTable",
     "StreamDevice",
     "StreamDevConfig",
     "StreamDevRuntime",
-    "StreamPlotterConfig",
     "iter_buffers",
 ]

--- a/mio/devices/stream/config.py
+++ b/mio/devices/stream/config.py
@@ -3,13 +3,70 @@
 from pathlib import Path
 from typing import Literal
 
-from pydantic import field_validator
+from pydantic import Field, field_validator
 
 from mio.const import INTERFACES_DIR
-from mio.devices.stream import StreamDevRuntime
 from mio.devices.stream.headers import ADCScaling
 from mio.models import MiniscopeConfig
 from mio.models.mixins import ConfigYAMLMixin
+from mio.models.sinks import CSVWriterConfig, StreamPlotterConfig
+
+
+class StreamDevRuntime(MiniscopeConfig):
+    """
+    Runtime configuration for :class:`.StreamDevice`
+
+    Included within :class:`.StreamDevConfig` to separate config that is not
+    unique to the device, but how that device is controlled at runtime.
+    """
+
+    serial_buffer_queue_size: int = Field(
+        10,
+        description="Buffer length for serial data reception in streamDaq",
+    )
+    frame_buffer_queue_size: int = Field(
+        10,
+        description="Buffer length for storing frames in streamDaq",
+    )
+    image_buffer_queue_size: int = Field(
+        10,
+        description="Buffer length for storing images in streamDaq",
+    )
+    queue_put_timeout: int = Field(
+        5,
+        description="Timeout for putting data into the queue",
+    )
+    plot: StreamPlotterConfig | None = Field(
+        StreamPlotterConfig(
+            keys=["timestamp", "buffer_count", "frame_buffer_count"], update_ms=1000, history=500
+        ),
+        description="Configuration for plotting header data as it is collected. "
+        "If ``None``, use the default params in StreamPlotter. "
+        "Note that this does *not* control whether header metadata is plotted during capture, "
+        "for enabling/disabling, use the ``show_metadata`` kwarg in the capture method",
+    )
+    csvwriter: CSVWriterConfig | None = Field(
+        CSVWriterConfig(buffer=100),
+        description="Default configuration for writing header data to a CSV file. "
+        "If ``None``, use the default params in BufferedCSVWriter. "
+        "Note that this does *not* control whether header metadata is written during capture, "
+        "for enabling/disabling, use the ``metadata`` kwarg in the capture method.",
+    )
+    ntp_server: str | None = Field(
+        default=None,
+        description="NTP server address for time synchronization check. "
+        "If specified, the system time will be verified against this server before capture.",
+    )
+    ntp_max_offset_seconds: float = Field(
+        default=0.01,
+        description="Maximum allowed time offset in seconds "
+        "for NTP synchronization check (default: 0.01 = 10ms).",
+    )
+    ber_test_n_buffers: int = Field(
+        32767,
+        description="Number of buffers to consume when running BER test mode. "
+        "Default is 2^15 - 1, one full cycle of the PRBS-15 seed space.",
+    )
 
 
 class StreamDevConfig(MiniscopeConfig, ConfigYAMLMixin):

--- a/mio/devices/stream/device.py
+++ b/mio/devices/stream/device.py
@@ -21,7 +21,7 @@ from mio import init_logger
 from mio.bit_operation import BufferFormatter
 from mio.devices.base import Device
 from mio.devices.stream.config import StreamDevConfig
-from mio.devices.stream.headers import RuntimeMetadata, StreamBufferHeader
+from mio.devices.stream.headers import StreamBufferHeader
 from mio.exceptions import EndOfRecordingException, StreamReadError
 from mio.interfaces.mocks import okDevMock
 from mio.io import BufferedCSVWriter, VideoWriter
@@ -153,15 +153,15 @@ class StreamDevice(Device):
             # trim if too long
             if data.shape[0] > expected_data_size:
                 data = data[0:expected_data_size]
-                header.runtime_metadata.black_padding_px = 0  # No padding, data was trimmed
+                header.black_padding_px = 0  # No padding, data was trimmed
             # pad if too short
             else:
                 padding_amount = expected_data_size - data.shape[0]
                 data = np.pad(data, (0, padding_amount))
-                header.runtime_metadata.black_padding_px = padding_amount
+                header.black_padding_px = padding_amount
         else:
             # No trimming or padding needed
-            header.runtime_metadata.black_padding_px = 0
+            header.black_padding_px = 0
 
         return data
 
@@ -256,7 +256,8 @@ class StreamDevice(Device):
                     )
                 except queue.Full:
                     locallogs.warning("Serial buffer queue full, skipping buffer.")
-
+        except Exception as e:
+            locallogs.exception(f"Exception in _fpga_recv: {e}")
         finally:
             locallogs.debug("Quitting, putting sentinel in queue")
             try:
@@ -291,13 +292,11 @@ class StreamDevice(Device):
             reverse_payload_bytes=self.config.reverse_payload_bytes,
         )
 
-        runtime_metadata = RuntimeMetadata(
+        runtime_metadata = dict(
             buffer_recv_index=-1,  # will be set later in _buffer_to_frame for processed buffers
             buffer_recv_unix_time=time.time(),
         )
-        header_data = StreamBufferHeader.from_sequence(
-            header.astype(int), runtime_metadata=runtime_metadata
-        )
+        header_data = StreamBufferHeader.from_sequence(header.astype(int), **runtime_metadata)
         header_data.adc_scaling = self.config.adc_scale
 
         return header_data, payload
@@ -496,7 +495,7 @@ class StreamDevice(Device):
                     continue
 
                 # update buffer_recv_index only for processed buffers
-                header_data.runtime_metadata.buffer_recv_index = self._buffer_recv_index
+                header_data.buffer_recv_index = self._buffer_recv_index
                 self._buffer_recv_index += 1
 
                 try:
@@ -552,6 +551,9 @@ class StreamDevice(Device):
                 frame_buffer[header_data.frame_buffer_count] = serial_buffer
                 header_list.append(header_data)
                 locallogs.debug("----buffer #" + str(header_data.frame_buffer_count) + " stored")
+        except Exception as e:
+            locallogs.exception(f"Exception in _buffer_to_frame: {e}")
+
         finally:
             try:
                 # get remaining buffers.
@@ -631,7 +633,7 @@ class StreamDevice(Device):
 
                 # Populate reconstructed_frame_index for all headers in this frame
                 for header in header_list:
-                    header.runtime_metadata.reconstructed_frame_index = frame_index_counter
+                    header.reconstructed_frame_index = frame_index_counter
 
                 try:
                     imagearray.put(
@@ -643,6 +645,8 @@ class StreamDevice(Device):
                     locallogs.warning("Image array queue full, skipping frame.")
 
                 frame_index_counter += 1
+        except Exception as e:
+            locallogs.exception(f"Exception in _format_frame: {e}")
         finally:
             locallogs.debug("Quitting, putting sentinel in queue")
             try:
@@ -869,7 +873,7 @@ class StreamDevice(Device):
                 if metadata:
                     self.logger.debug("Saving header metadata")
                     try:
-                        meta_row = header.model_dump_all()
+                        meta_row = header.model_dump()
                         self._buffered_writer.append(meta_row)
                     except Exception as e:
                         self.logger.exception(f"Exception saving headers: \n{e}")

--- a/mio/devices/stream/headers.py
+++ b/mio/devices/stream/headers.py
@@ -1,19 +1,13 @@
 """Headers & metadata for stream devices"""
 
-import sys
-from collections.abc import Sequence
 from typing import ClassVar
 
+import pandera.pandas as pa
 from pydantic import Field, computed_field
 
 from mio.devices.base.headers import BufferHeader
 from mio.models import MiniscopeConfig
-from mio.models.sinks import CSVWriterConfig, StreamPlotterConfig
-
-if sys.version_info < (3, 11):
-    from typing_extensions import Self
-else:
-    from typing import Self
+from mio.models.models import Table
 
 
 class ADCScaling(MiniscopeConfig):
@@ -68,6 +62,35 @@ class RuntimeMetadata(MiniscopeConfig):
     Runtime metadata for data streams.
     """
 
+
+class StreamBufferHeader(BufferHeader):
+    """
+    Refinements of :class:`.BufferHeader` for
+    :class:`~mio.devices.stream.StreamDevice`
+
+    Additional runtime keys not specified in ``POSITIONS`` must be provided
+    when instantiating the object as ``kwargs`` to the ``from_sequence`` method.
+    """
+
+    POSITIONS: ClassVar[dict[str, int]] = {
+        "linked_list": 0,
+        "frame_num": 1,
+        "buffer_count": 2,
+        "frame_buffer_count": 3,
+        "write_buffer_count": 4,
+        "dropped_buffer_count": 5,
+        "timestamp": 6,
+        "write_timestamp": 8,
+        "pixel_count": 7,
+        "battery_voltage_raw": 9,
+        "input_voltage_raw": 10,
+    }
+
+    pixel_count: int
+    battery_voltage_raw: int
+    input_voltage_raw: int
+
+    # runtime metadata
     buffer_recv_index: int = Field(
         -1,
         description=(
@@ -97,33 +120,7 @@ class RuntimeMetadata(MiniscopeConfig):
         ),
     )
 
-
-class StreamBufferHeader(BufferHeader):
-    """
-    Refinements of :class:`.BufferHeader` for
-    :class:`~mio.devices.stream.StreamDevice`
-    """
-
-    POSITIONS: ClassVar[dict[str, int]] = {
-        "linked_list": 0,
-        "frame_num": 1,
-        "buffer_count": 2,
-        "frame_buffer_count": 3,
-        "write_buffer_count": 4,
-        "dropped_buffer_count": 5,
-        "timestamp": 6,
-        "write_timestamp": 8,
-        "pixel_count": 7,
-        "battery_voltage_raw": 9,
-        "input_voltage_raw": 10,
-    }
-
-    pixel_count: int
-    battery_voltage_raw: int
-    input_voltage_raw: int
     _adc_scaling: ADCScaling = None
-
-    runtime_metadata: RuntimeMetadata = Field(default_factory=lambda: RuntimeMetadata())
 
     @property
     def adc_scaling(self) -> ADCScaling | None:
@@ -156,124 +153,26 @@ class StreamBufferHeader(BufferHeader):
         else:
             return self._adc_scaling.scale_input_voltage(self.input_voltage_raw)
 
-    def model_dump_all(self, warning: bool = False) -> dict:
-        """
-        Return a dictionary of the model values, including runtime metadata if available.
 
-        Returns:
-            dict: Dictionary of model values
-        """
-        meta_row = self.model_dump(warnings=warning)
-        if "runtime_metadata" in meta_row and meta_row["runtime_metadata"]:
-            runtime_data = meta_row.pop("runtime_metadata")
-            meta_row.update(runtime_data)
-
-        return meta_row
-
-    @classmethod
-    def from_sequence(
-        cls,
-        vals: Sequence,
-        construct: bool = False,
-        runtime_metadata: RuntimeMetadata = None,
-    ) -> Self:
-        """
-        Instantiate a stream buffer header from linearized values (eg. in an ndarray or list),
-        an associated format that tells us what index the model values are found in that data,
-        and runtime metadata container.
-
-        Args:
-            vals (list, :class:`numpy.ndarray` ): Indexable values to cast to the header model
-            construct (bool): If ``True`` , use :meth:`~pydantic.BaseModel.model_construct`
-                to create the model instance (ie. without validation, but faster).
-                Default: ``False``
-            runtime_metadata (:class:`.RuntimeMetadata`, optional): Runtime metadata
-             to attach to the header.
-
-        Returns:
-            :class:`.StreamBufferHeader`
-        """
-        header = super().from_sequence(vals=vals, construct=construct)
-        if runtime_metadata is not None:
-            header.runtime_metadata = runtime_metadata
-        return header
-
-    @classmethod
-    def csv_header_cols(cls) -> list[str]:
-        """
-        Return the standardized column names for CSV output.
-
-        This ensures consistent column ordering across all StreamBufferHeader instances
-        when writing to CSV files.
-
-        Args:
-            header_format: The StreamBufferHeaderFormat instance to get column ordering from
-
-        Returns:
-            list[str]: Column names in the order they should appear in CSV output
-        """
-        # Get the base header format columns (excluding internal fields)
-        header_items = sorted(cls.POSITIONS.items(), key=lambda x: x[1])
-        base_cols = [name for name, _ in header_items]
-
-        # Add runtime metadata fields from the class's own runtime_metadata attribute
-        runtime_fields = list(cls.model_fields["runtime_metadata"].annotation.model_fields.keys())
-
-        return base_cols + runtime_fields
-
-
-class StreamDevRuntime(MiniscopeConfig):
+class StreamBufferTable(Table):
     """
-    Runtime configuration for :class:`.StreamDevice`
-
-    Included within :class:`.StreamDevConfig` to separate config that is not
-    unique to the device, but how that device is controlled at runtime.
+    Table form of the stream
     """
 
-    serial_buffer_queue_size: int = Field(
-        10,
-        description="Buffer length for serial data reception in streamDaq",
-    )
-    frame_buffer_queue_size: int = Field(
-        5,
-        description="Buffer length for storing frames in streamDaq",
-    )
-    image_buffer_queue_size: int = Field(
-        5,
-        description="Buffer length for storing images in streamDaq",
-    )
-    queue_put_timeout: int = Field(
-        5,
-        description="Timeout for putting data into the queue",
-    )
-    plot: StreamPlotterConfig | None = Field(
-        StreamPlotterConfig(
-            keys=["timestamp", "buffer_count", "frame_buffer_count"], update_ms=1000, history=500
-        ),
-        description="Configuration for plotting header data as it is collected. "
-        "If ``None``, use the default params in StreamPlotter. "
-        "Note that this does *not* control whether header metadata is plotted during capture, "
-        "for enabling/disabling, use the ``show_metadata`` kwarg in the capture method",
-    )
-    csvwriter: CSVWriterConfig | None = Field(
-        CSVWriterConfig(buffer=100),
-        description="Default configuration for writing header data to a CSV file. "
-        "If ``None``, use the default params in BufferedCSVWriter. "
-        "Note that this does *not* control whether header metadata is written during capture, "
-        "for enabling/disabling, use the ``metadata`` kwarg in the capture method.",
-    )
-    ntp_server: str | None = Field(
-        default=None,
-        description="NTP server address for time synchronization check. "
-        "If specified, the system time will be verified against this server before capture.",
-    )
-    ntp_max_offset_seconds: float = Field(
-        default=0.01,
-        description="Maximum allowed time offset in seconds "
-        "for NTP synchronization check (default: 0.01 = 10ms).",
-    )
-    ber_test_n_buffers: int = Field(
-        32767,
-        description="Number of buffers to consume when running BER test mode. "
-        "Default is 2^15 - 1, one full cycle of the PRBS-15 seed space.",
-    )
+    _RECORD_MODEL = StreamBufferHeader
+
+    linked_list: int = pa.Field(ge=0, coerce=True)
+    frame_num: int = pa.Field(ge=0, coerce=True)
+    buffer_count: int = pa.Field(ge=0, coerce=True)
+    frame_buffer_count: int = pa.Field(ge=0, coerce=True)
+    write_buffer_count: int = pa.Field(ge=0, coerce=True)
+    dropped_buffer_count: int = pa.Field(ge=0, coerce=True)
+    timestamp: int = pa.Field(ge=0, coerce=True)
+    pixel_count: int = pa.Field(ge=0, coerce=True)
+    write_timestamp: int = pa.Field(ge=0, coerce=True)
+    battery_voltage_raw: float = pa.Field(ge=0, coerce=True)
+    input_voltage_raw: float = pa.Field(ge=0, coerce=True)
+    buffer_recv_index: int = pa.Field(ge=0, coerce=True)
+    buffer_recv_unix_time: float = pa.Field(ge=0, coerce=True)
+    black_padding_px: int = pa.Field(ge=0, coerce=True)
+    reconstructed_frame_index: int = pa.Field(ge=0, coerce=True)

--- a/mio/devices/tables.py
+++ b/mio/devices/tables.py
@@ -1,0 +1,75 @@
+"""Shared metadata models"""
+
+from __future__ import annotations
+
+import pandera.pandas as pa
+
+from mio.models import Container, Table
+
+
+class TimestampTable(pa.DataFrameModel):
+    """Summary of timestamps per frame for a recording"""
+
+    frame: int
+    timestamp_first: float
+    timestamp_last: float
+
+
+class NoiseTable(pa.DataFrameModel):
+    """
+    Scores for noise values for a recording,
+    produced by :func:`mio.process.video.score_noise`
+    """
+
+    reconstructed_frame_index: int = pa.Field(ge=0, coerce=True)
+    black_area: int | None = pa.Field(ge=0, coerce=True)
+    gradient: float | None = pa.Field(ge=0, coerce=True)
+
+
+class StitchRecord(Container):
+    """
+    Row schema for debug metadata emitted during stitching.
+
+    The field order defines the CSV header order.
+    """
+
+    index: int
+    frame_num: int | None = None
+    selected_video: str
+    compare_video: str | None = None
+    selected_num_buffers: int
+    selected_black_padding: int
+    selected_black_pixels: int
+    selected_noisy_pixels: int
+    compare_num_buffers: int | None = None
+    compare_black_padding: int | None = None
+    compare_black_pixels: int | None = None
+    compare_noisy_pixels: int | None = None
+    selected_edge_score: float | None = None
+    compare_edge_score: float | None = None
+
+    @classmethod
+    def header(cls) -> list[str]:
+        """Return CSV header preserving declared field order."""
+        return list(cls.model_fields.keys())
+
+
+class StitchTable(Table):
+    """Table model for stitching scores"""
+
+    _RECORD_MODEL = StitchRecord
+
+    index: int = pa.Field(ge=0, coerce=True)
+    frame_num: int = pa.Field(default=None, ge=0, coerce=True, nullable=True)
+    selected_video: str
+    compare_video: str = pa.Field(default=None, coerce=True, nullable=True)
+    selected_num_buffers: int
+    selected_black_padding: int
+    selected_black_pixels: int
+    selected_noisy_pixels: int
+    compare_num_buffers: int = pa.Field(default=None, ge=0, coerce=True, nullable=True)
+    compare_black_padding: int = pa.Field(default=None, ge=0, coerce=True, nullable=True)
+    compare_black_pixels: int = pa.Field(default=None, ge=0, coerce=True, nullable=True)
+    compare_noisy_pixels: int = pa.Field(default=None, ge=0, coerce=True, nullable=True)
+    selected_edge_score: float = pa.Field(default=None, coerce=True, nullable=True)
+    compare_edge_score: float = pa.Field(default=None, coerce=True, nullable=True)

--- a/mio/logging.py
+++ b/mio/logging.py
@@ -31,15 +31,15 @@ def init_logger(
             and indicate what they are logging for, eg. ``mio.sdcard``
             and don't contain metadata like timestamps, etc. (which are in the logs)
         log_dir (:class:`pathlib.Path`): Directory to store file-based logs in. If ``None``,
-            get from :class:`.Config`. If ``False`` , disable file logging.
+            get from :class:`~.mio.models.config.Config`. If ``False`` , disable file logging.
         level (:class:`.LOG_LEVELS`): Level to use for stdout logging. If ``None`` ,
             get from :class:`.Config`
         file_level (:class:`.LOG_LEVELS`): Level to use for file-based logging.
-             If ``None`` , get from :class:`.Config`
+             If ``None`` , get from :class:`~.mio.models.config.Config`
         log_file_n (int): Number of rotating file logs to use.
-            If ``None`` , get from :class:`.Config`
+            If ``None`` , get from :class:`~.mio.models.config.Config`
         log_file_size (int): Maximum size of logfiles before rotation.
-            If ``None`` , get from :class:`.Config`
+            If ``None`` , get from :class:`~.mio.models.config.Config`
 
     Returns:
         :class:`logging.Logger`

--- a/mio/logging.py
+++ b/mio/logging.py
@@ -33,7 +33,7 @@ def init_logger(
         log_dir (:class:`pathlib.Path`): Directory to store file-based logs in. If ``None``,
             get from :class:`~.mio.models.config.Config`. If ``False`` , disable file logging.
         level (:class:`.LOG_LEVELS`): Level to use for stdout logging. If ``None`` ,
-            get from :class:`.Config`
+            get from :class:`~.mio.models.config.Config`
         file_level (:class:`.LOG_LEVELS`): Level to use for file-based logging.
              If ``None`` , get from :class:`~.mio.models.config.Config`
         log_file_n (int): Number of rotating file logs to use.

--- a/mio/models/__init__.py
+++ b/mio/models/__init__.py
@@ -4,7 +4,7 @@ Data models :)
 
 # ruff: noqa: I001 - import order meaningful here to avoid cycles
 
-from mio.models.models import Container, MiniscopeConfig, MiniscopeIOModel
+from mio.models.models import Container, MiniscopeConfig, MiniscopeIOModel, Table
 
 from mio.models.process import DenoiseConfig, FrequencyMaskingConfig
 from mio.models.update import UpdateBatch
@@ -15,5 +15,6 @@ __all__ = [
     "FrequencyMaskingConfig",
     "MiniscopeConfig",
     "MiniscopeIOModel",
+    "Table",
     "UpdateBatch",
 ]

--- a/mio/models/dataset.py
+++ b/mio/models/dataset.py
@@ -65,6 +65,7 @@ from typing import Any, Literal, TypeAlias
 import pandas as pd
 from numpydantic import NDArraySchema
 from numpydantic.interface.video import VideoProxy
+from pandera.typing.pandas import DataFrame
 from pydantic import (
     ConfigDict,
     Discriminator,
@@ -73,6 +74,8 @@ from pydantic import (
     model_validator,
 )
 
+from mio.devices.stream import StreamBufferTable
+from mio.devices.tables import NoiseTable, StitchTable, TimestampTable
 from mio.models import MiniscopeIOModel
 from mio.models.process import NoisePatchConfig
 from mio.utils import _format_ranges
@@ -134,15 +137,15 @@ class Recording(MiniscopeIOModel):
     """What type of recording this is"""
     video: VideoType
     """A video created as part of this recording"""
-    metadata: pd.DataFrame | None = None
+    metadata: DataFrame[StreamBufferTable] | None = None
     """Metadata for frames within the video"""
-    timestamps: pd.DataFrame | None = None
+    timestamps: DataFrame[TimestampTable] | None = None
     """
     Timestamps table, (currently) stored as ``{video_name}_timestamps.csv`` next to the video.
     When instantiating a recording, if a metadata file exists but timestamps do not,
     they are automatically generated. 
     """
-    noise: pd.DataFrame | None = None
+    noise: DataFrame[NoiseTable] | None = None
     """
     Framewise noise measurements (created with :meth:`score_noise` ).
     """
@@ -256,8 +259,8 @@ class StitchedRecording(Recording):
     """Multiple video recordings stitched together, picking one best aligned frame from each"""
 
     type: Literal["stitched"] = "stitched"
-    metadata: pd.DataFrame
-    scores: pd.DataFrame
+    metadata: DataFrame[StreamBufferTable]
+    scores: DataFrame[StitchTable]
     """A csv that indicates which recording each stitched frame was selected from"""
     derived_from: RecordingDerivation
     """A derivation reference that indicates which videos this stitch was derived from"""

--- a/mio/models/models.py
+++ b/mio/models/models.py
@@ -2,6 +2,12 @@
 Base and meta model classes.
 """
 
+from pathlib import Path
+from typing import Any, ClassVar, Self
+
+import pandas as pd
+import pandera.pandas as pa
+from pandera.typing import DataFrame
 from pydantic import BaseModel
 
 
@@ -32,3 +38,18 @@ class Container(MiniscopeIOModel):
 
     See also: :class:`.MiniscopeConfig`
     """
+
+
+class Table(pa.DataFrameModel):
+    """
+    Root model for metadata tables.
+    Each table should have a corresponding record model for its individual rows
+    """
+
+    _RECORD_MODEL: ClassVar[type[Container] | None] = None
+
+    @classmethod
+    def read_csv(cls, path: Path, **kwargs: dict[str, Any]) -> DataFrame[Self]:
+        """Read and validate a table as a csv"""
+        df = pd.read_csv(path, **kwargs)
+        return cls.validate(df, inplace=True)

--- a/mio/models/models.py
+++ b/mio/models/models.py
@@ -2,13 +2,19 @@
 Base and meta model classes.
 """
 
+import sys
 from pathlib import Path
-from typing import Any, ClassVar, Self
+from typing import Any, ClassVar
 
 import pandas as pd
 import pandera.pandas as pa
 from pandera.typing import DataFrame
 from pydantic import BaseModel
+
+if sys.version_info < (3, 11):
+    from typing_extensions import Self
+else:
+    from typing import Self
 
 
 class MiniscopeIOModel(BaseModel):

--- a/mio/process/stitch.py
+++ b/mio/process/stitch.py
@@ -16,9 +16,9 @@ from pathlib import Path
 import cv2
 import numpy as np
 import pandas as pd
-from pydantic import BaseModel
 from tqdm import tqdm, trange
 
+from mio.devices.tables import StitchRecord
 from mio.io import BufferedCSVWriter, VideoWriter
 from mio.logging import init_logger
 from mio.models.dataset import Dataset, Recording, StitchedRecording, paths_from_video
@@ -302,34 +302,6 @@ def _score_edges(frame: np.ndarray) -> float:
     gx = cv2.Sobel(frame, cv2.CV_16S, 1, 0, ksize=3)
     gy = cv2.Sobel(frame, cv2.CV_16S, 0, 1, ksize=3)
     return -float(np.abs(gx).sum() + np.abs(gy).sum())
-
-
-class StitchRecord(BaseModel):
-    """
-    Row schema for debug metadata emitted during stitching.
-
-    The field order defines the CSV header order.
-    """
-
-    index: int
-    frame_num: int | None = None
-    selected_video: str
-    compare_video: str | None = None
-    selected_num_buffers: int
-    selected_black_padding: int
-    selected_black_pixels: int
-    selected_noisy_pixels: int
-    compare_num_buffers: int | None = None
-    compare_black_padding: int | None = None
-    compare_black_pixels: int | None = None
-    compare_noisy_pixels: int | None = None
-    selected_edge_score: float | None = None
-    compare_edge_score: float | None = None
-
-    @classmethod
-    def header(cls) -> list[str]:
-        """Return CSV header preserving declared field order."""
-        return list(cls.model_fields.keys())
 
 
 def _select_best_candidate(

--- a/mio/process/video.py
+++ b/mio/process/video.py
@@ -8,9 +8,12 @@ from pathlib import Path
 import cv2
 import numpy as np
 import pandas as pd
+from pandera.typing.pandas import DataFrame
 from tqdm import tqdm, trange
 
 from mio import init_logger
+from mio.devices.stream import StreamBufferTable
+from mio.devices.tables import NoiseTable, TimestampTable
 from mio.io import VideoReader, VideoWriter
 from mio.models.dataset import Recording
 from mio.models.frames import NamedFrame, NamedVideo
@@ -618,7 +621,7 @@ def denoise(
 
 def score_noise(
     recording: Recording, config: NoisePatchConfig, progress: bool = False
-) -> pd.DataFrame:
+) -> DataFrame[NoiseTable]:
     """
     Score framewise noise from a recording,
     yielding a dataframe with columns for each kind of noise
@@ -853,7 +856,7 @@ def _drop_frames_by_index(
     return filtered
 
 
-def _make_frame_timestamp_csv(csv_df: pd.DataFrame) -> pd.DataFrame:
+def _make_frame_timestamp_csv(csv_df: DataFrame[StreamBufferTable]) -> DataFrame[TimestampTable]:
     """
     Export a frame-timestamp CSV file mapping reconstructed_frame_index to unix timestamps.
 

--- a/tests/test_devices/test_stream.py
+++ b/tests/test_devices/test_stream.py
@@ -160,14 +160,7 @@ def test_csv_output(tmp_path, default_streamdaq, write_metadata, caplog):
         # we should have the same columns in the same order as our header format
         # plus reconstruction metadata
         col_names = df.columns.to_list()
-        expected = [h[0] for h in sorted(StreamBufferHeader.POSITIONS.items(), key=lambda x: x[1])]
-
-        # Add runtime_metadata fields
-        from mio.devices.stream.headers import RuntimeMetadata
-
-        runtime_fields = list(RuntimeMetadata.model_fields.keys())
-        expected.extend(runtime_fields)
-        assert col_names == expected
+        assert col_names == StreamBufferHeader.csv_header_cols()
 
         # ensure there were no errors during capture
         for record in caplog.records:

--- a/tests/test_models/test_model_dataset.py
+++ b/tests/test_models/test_model_dataset.py
@@ -9,9 +9,13 @@ from ..conftest import DATA_DIR
 
 def test_recording_trim_metadata():
     vid_path = DATA_DIR / "stitch" / "video1.avi"
+    metadata = pd.read_csv(vid_path.with_suffix(".csv"))
+    metadata_list = metadata.values.tolist()
+    metadata_list.append(metadata_list[-1])
+    metadata = pd.DataFrame(metadata_list, columns=metadata.columns)
+    metadata.iloc[-1]["reconstructed_frame_index"] += 1
     vid = VideoProxy(vid_path)
     n_frames = vid.shape[0]
-    metadata = pd.DataFrame({"reconstructed_frame_index": list(range(n_frames + 1))})
 
     with pytest.warns(UserWarning):
         recording = Recording(name="video1", type="raw", video=vid_path, metadata=metadata)

--- a/tests/test_models/test_model_dataset.py
+++ b/tests/test_models/test_model_dataset.py
@@ -10,14 +10,13 @@ from ..conftest import DATA_DIR
 def test_recording_trim_metadata():
     vid_path = DATA_DIR / "stitch" / "video1.avi"
     metadata = pd.read_csv(vid_path.with_suffix(".csv"))
-    metadata_list = metadata.values.tolist()
-    metadata_list.append(metadata_list[-1])
-    metadata = pd.DataFrame(metadata_list, columns=metadata.columns)
-    metadata.iloc[-1]["reconstructed_frame_index"] += 1
+    metadata.loc[metadata.index[-1], "reconstructed_frame_index"] += 1
     vid = VideoProxy(vid_path)
     n_frames = vid.shape[0]
+
+    assert int(metadata["reconstructed_frame_index"].max()) == n_frames
 
     with pytest.warns(UserWarning):
         recording = Recording(name="video1", type="raw", video=vid_path, metadata=metadata)
 
-    assert recording.metadata["reconstructed_frame_index"].max() == n_frames - 1
+    assert int(recording.metadata["reconstructed_frame_index"].max()) == n_frames - 1

--- a/tests/test_models/test_model_table.py
+++ b/tests/test_models/test_model_table.py
@@ -1,0 +1,27 @@
+import pytest
+
+from mio.devices.base import BufferHeader
+from mio.models import Table
+
+
+def _subclasses(cls: type) -> list[type]:
+    subs = []
+    my_subs = cls.__subclasses__()
+    subs.extend(my_subs)
+    for sub in my_subs:
+        subs.extend(_subclasses(sub))
+    return subs
+
+
+@pytest.mark.parametrize("table", _subclasses(Table))
+def test_table_models_match_records(table: Table):
+    """All table models should match their indicated record model"""
+    if table._RECORD_MODEL is None:
+        return
+
+    if issubclass(table._RECORD_MODEL, BufferHeader):
+        record_fields = table._RECORD_MODEL.csv_header_cols()
+    else:
+        record_fields = list(table._RECORD_MODEL.model_fields.keys())
+
+    assert record_fields == list(table.build_schema_().columns.keys())

--- a/tests/test_process/test_stitch.py
+++ b/tests/test_process/test_stitch.py
@@ -11,9 +11,9 @@ import numpy as np
 import pandas as pd
 import pytest
 
+from mio.devices.tables import StitchRecord
 from mio.models.dataset import Recording, StitchedRecording
 from mio.process.stitch import (
-    StitchRecord,
     _align_by_time,
     _has_discontinuous_runs,
     _score_edges,


### PR DESCRIPTION
Fix: #171 

Just replacing the structured tables that we have described in the dataset class for now, but we are edging towards a structure - we have some mapping between filenames and table types, and we will eventually have a declarative config that maps that for us instead of it being implicit in the filename.

The structure is pretty ungainly right now as i need to wrangle all the implicit tables that have been created in different places as i smooth out the general structure of the thing, but this is at least a starting point.

the reason that we have to duplicate record and table models is basically [this](https://pandera.readthedocs.io/en/stable/pydantic_integration.html#using-pydantic-models-in-pandera-schemas):

> By combining dtype=PydanticModel(...) and coerce=True, pandera will apply the pydantic model validation process to each row of the dataframe, converting the model back to a dictionary with the BaseModel.dict() method.
> 
> Since the PydanticModel datatype applies the BaseModel constructor to each row of the dataframe, using PydanticModel might not scale well with larger datasets.

so it's unfortunate, but they also have slightly different structure anyway - e.g. the stitch record has individual fields as being int | None, but that's different than saying 'a column is optional' - the corresponding schema declaration is that the column must exist but is nullable.

<!-- readthedocs-preview miniscope-io start -->
----
📚 Documentation preview 📚: https://miniscope-io--183.org.readthedocs.build/en/183/

<!-- readthedocs-preview miniscope-io end -->